### PR TITLE
corrected node-llama-cpp command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ TWITTER_COOKIES= # Account cookies
 If you have an NVIDIA GPU, you can install CUDA to speed up local inference dramatically.
 ```
 npm install
-npx --no node-llama-cpp download --gpu cuda
+npx --no node-llama-cpp source download --gpu cuda
 ```
 
 Make sure that you've installed the CUDA Toolkit, including cuDNN and cuBLAS.


### PR DESCRIPTION
The original command produces this: 
![image](https://github.com/user-attachments/assets/652495c4-50da-45bd-b4d2-d8f5e34e7516)

The documentation shows the correct command is `npx --no node-llama-cpp source download --gpu cuda`
![image](https://github.com/user-attachments/assets/79b126e5-5635-4457-98e4-dae250a37a0a)
