### PR TITLE
181  generate changelog

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -14,4 +14,4 @@ jobs:
           github_changelog_generator \
             -u ${{ github.repository_owner }} \
             -p ${{ github.event.repository.name }} \
-            --token ${{ secrets.GITHUB_TOKEN }}
+            --token ${{ secrets.CHANGELOG_GITHUB_TOKEN }}

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -1,0 +1,17 @@
+name: Generate Changelog
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate Changelog
+        run: |
+          gem install github_changelog_generator
+          github_changelog_generator \
+            -u ${{ github.repository_owner }} \
+            -p ${{ github.event.repository.name }} \
+            --token ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding a github action for generating a CHANGELOG.md file automatically when a new tag is created.

# Relates to:

Closes #181

# Risks

low

# Background

## What does this PR do?
Add a github action that create a CHANGELOG.md file

## What kind of change is this?
Features (non-breaking change which adds functionality)

# Testing
1. create a new tag
2. verify that a changelog was added to the repo
