### PR TITLE
Update generate-changelog.yml

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -7,7 +7,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Generate Changelog
         run: |
           gem install github_changelog_generator


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

bumps the github action to v4 for the correct version of node

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The github action for generating the changelog is failing. advice from smokyboo is to bump the action to v4 which should give us the correct version

# Testing

create a tag after this is in place and check to ensure that the job doesn't fail and a changelog is created.
