### PR TITLE
Support google models in generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ OPENAI_API_KEY=sk-* # OpenAI API key, starting with sk-
 REDPILL_API_KEY= # REDPILL API Key
 GROQ_API_KEY=gsk_*
 OPENROUTER_API_KEY=
+GOOGLE_GENERATIVE_AI_API_KEY= # Gemini API key
 
 ELEVENLABS_XI_API_KEY= # API key from elevenlabs
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ DISCORD_APPLICATION_ID=
 DISCORD_API_TOKEN= # Bot token
 OPENAI_API_KEY=sk-* # OpenAI API key, starting with sk-
 ELEVENLABS_XI_API_KEY= # API key from elevenlabs
+GOOGLE_GENERATIVE_AI_API_KEY= # Gemini API key
 
 # ELEVENLABS SETTINGS
 ELEVENLABS_MODEL_ID=eleven_multilingual_v2

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -11,6 +11,7 @@ import { default as tiktoken, TiktokenModel } from "tiktoken";
 import Together from "together-ai";
 import { elizaLogger } from "./index.ts";
 import models from "./models.ts";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import {
     parseBooleanFromText,
     parseJsonArrayFromText,
@@ -64,6 +65,7 @@ export async function generateText({
     const presence_penalty = models[provider].settings.presence_penalty;
     const max_context_length = models[provider].settings.maxInputTokens;
     const max_response_length = models[provider].settings.maxOutputTokens;
+    const systemPrompt = runtime.systemPrompt;
 
     const apiKey = runtime.token;
 
@@ -103,6 +105,22 @@ export async function generateText({
                 elizaLogger.log("Received response from OpenAI model.");
                 break;
             }
+
+            case ModelProviderName.GOOGLE:
+                const google = createGoogleGenerativeAI();
+
+                const { text: anthropicResponse } = await aiGenerateText({
+                    model: google(model),
+                    prompt: context,
+                    ...(systemPrompt ? { system: systemPrompt } : {}),
+                    temperature: temperature,
+                    maxTokens: max_response_length,
+                    frequencyPenalty: frequency_penalty,
+                    presencePenalty: presence_penalty,
+                });
+
+                response = anthropicResponse;
+                break;
 
             case ModelProviderName.ANTHROPIC: {
                 elizaLogger.log("Initializing Anthropic model.");
@@ -214,7 +232,6 @@ export async function generateText({
                 break;
             }
 
-
             case ModelProviderName.OPENROUTER: {
                 elizaLogger.log("Initializing OpenRouter model.");
                 const serverUrl = models[provider].endpoint;
@@ -237,7 +254,6 @@ export async function generateText({
                 elizaLogger.log("Received response from OpenRouter model.");
                 break;
             }
-
 
             case ModelProviderName.OLLAMA:
                 {
@@ -425,10 +441,13 @@ export async function generateTrueOrFalse({
     modelClass: string;
 }): Promise<boolean> {
     let retryDelay = 1000;
-    console.log("modelClass", modelClass)
+    console.log("modelClass", modelClass);
 
     const stop = Array.from(
-        new Set([...(models[runtime.modelProvider].settings.stop || []), ["\n"]])
+        new Set([
+            ...(models[runtime.modelProvider].settings.stop || []),
+            ["\n"],
+        ])
     ) as string[];
 
     while (true) {

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -65,7 +65,6 @@ export async function generateText({
     const presence_penalty = models[provider].settings.presence_penalty;
     const max_context_length = models[provider].settings.maxInputTokens;
     const max_response_length = models[provider].settings.maxOutputTokens;
-    const systemPrompt = runtime.systemPrompt;
 
     const apiKey = runtime.token;
 
@@ -112,7 +111,10 @@ export async function generateText({
                 const { text: anthropicResponse } = await aiGenerateText({
                     model: google(model),
                     prompt: context,
-                    ...(systemPrompt ? { system: systemPrompt } : {}),
+                    system:
+                        runtime.character.system ??
+                        settings.SYSTEM_PROMPT ??
+                        undefined,
                     temperature: temperature,
                     maxTokens: max_response_length,
                     frequencyPenalty: frequency_penalty,

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -137,9 +137,9 @@ const models: Models = {
             temperature: 0.3,
         },
         model: {
-            [ModelClass.SMALL]: "gemini-1.5-flash",
-            [ModelClass.MEDIUM]: "gemini-1.5-flash",
-            [ModelClass.LARGE]: "gemini-1.5-pro",
+            [ModelClass.SMALL]: "gemini-1.5-flash-latest",
+            [ModelClass.MEDIUM]: "gemini-1.5-flash-latest",
+            [ModelClass.LARGE]: "gemini-1.5-pro-latest",
             [ModelClass.EMBEDDING]: "text-embedding-004",
         },
     },
@@ -187,8 +187,7 @@ const models: Models = {
                 settings.LARGE_OPENROUTER_MODEL ||
                 settings.OPENROUTER_MODEL ||
                 "nousresearch/hermes-3-llama-3.1-405b",
-            [ModelClass.EMBEDDING]: 
-                "text-embedding-3-small",
+            [ModelClass.EMBEDDING]: "text-embedding-3-small",
         },
     },
     [ModelProviderName.OLLAMA]: {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -93,12 +93,6 @@ export class AgentRuntime implements IAgentRuntime {
     modelProvider: ModelProviderName;
 
     /**
-     *
-     * The system prompt to use for the agent.
-     */
-    systemPrompt?: string;
-
-    /**
      * Fetch function to use
      * Some environments may not have access to the global fetch function and need a custom fetch override.
      */
@@ -213,7 +207,6 @@ export class AgentRuntime implements IAgentRuntime {
         fetch?: typeof fetch | unknown;
         speechModelPath?: string;
     }) {
-        this.systemPrompt = opts.character.system;
         this.#conversationLength =
             opts.conversationLength ?? this.#conversationLength;
         this.databaseAdapter = opts.databaseAdapter;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -93,6 +93,12 @@ export class AgentRuntime implements IAgentRuntime {
     modelProvider: ModelProviderName;
 
     /**
+     *
+     * The system prompt to use for the agent.
+     */
+    systemPrompt?: string;
+
+    /**
      * Fetch function to use
      * Some environments may not have access to the global fetch function and need a custom fetch override.
      */
@@ -207,6 +213,7 @@ export class AgentRuntime implements IAgentRuntime {
         fetch?: typeof fetch | unknown;
         speechModelPath?: string;
     }) {
+        this.systemPrompt = opts.character.system;
         this.#conversationLength =
             opts.conversationLength ?? this.#conversationLength;
         this.databaseAdapter = opts.databaseAdapter;
@@ -498,14 +505,14 @@ export class AgentRuntime implements IAgentRuntime {
      * @returns The results of the evaluation.
      */
     async evaluate(message: Memory, state?: State, didRespond?: boolean) {
-        console.log("Evaluate: ", didRespond)
+        console.log("Evaluate: ", didRespond);
         const evaluatorPromises = this.evaluators.map(
             async (evaluator: Evaluator) => {
-                console.log("Evaluating", evaluator.name)
+                console.log("Evaluating", evaluator.name);
                 if (!evaluator.handler) {
                     return null;
                 }
-                if(!didRespond && !evaluator.alwaysRun) {
+                if (!didRespond && !evaluator.alwaysRun) {
                     return null;
                 }
                 const result = await evaluator.validate(this, message, state);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -526,6 +526,7 @@ export interface IAgentRuntime {
     providers: Provider[];
     actions: Action[];
     evaluators: Evaluator[];
+    systemPrompt?: string;
 
     messageManager: IMemoryManager;
     descriptionManager: IMemoryManager;
@@ -550,7 +551,11 @@ export interface IAgentRuntime {
         state?: State,
         callback?: HandlerCallback
     ): Promise<void>;
-    evaluate(message: Memory, state?: State, didRespond?: boolean): Promise<string[]>;
+    evaluate(
+        message: Memory,
+        state?: State,
+        didRespond?: boolean
+    ): Promise<string[]>;
     ensureParticipantExists(userId: UUID, roomId: UUID): Promise<void>;
     ensureUserExists(
         userId: UUID,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -526,7 +526,6 @@ export interface IAgentRuntime {
     providers: Provider[];
     actions: Action[];
     evaluators: Evaluator[];
-    systemPrompt?: string;
 
     messageManager: IMemoryManager;
     descriptionManager: IMemoryManager;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,33 +709,6 @@ importers:
         specifier: 7.1.0
         version: 7.1.0
 
-  packages/test:
-    dependencies:
-      '@ai16z/adapter-sqlite':
-        specifier: workspace:*
-        version: link:../adapter-sqlite
-      '@ai16z/adapter-sqljs':
-        specifier: workspace:*
-        version: link:../adapter-sqljs
-      '@ai16z/adapter-supabase':
-        specifier: workspace:*
-        version: link:../adapter-supabase
-      '@ai16z/eliza':
-        specifier: workspace:*
-        version: link:../core
-      '@ai16z/plugin-bootstrap':
-        specifier: workspace:*
-        version: link:../plugin-bootstrap
-      '@ai16z/plugin-node':
-        specifier: workspace:*
-        version: link:../plugin-node
-      tsup:
-        specifier: ^8.3.5
-        version: 8.3.5(jiti@1.21.6)(postcss@8.4.47)(tsx@4.19.2)(typescript@5.6.3)(yaml@2.6.0)
-      whatwg-url:
-        specifier: 7.1.0
-        version: 7.1.0
-
 packages:
 
   '@ai-sdk/anthropic@0.0.53':


### PR DESCRIPTION
# Relates to:

No issue for ticket for this yet.

# Risks

Low risk.

# Background

## What does this PR do?

This PR adds support for the Google models, which are represented in the types but not implemented in the generation file.  Adds env ket to example env file and main readme env example.

## What kind of change is this?

Features (non-breaking change which adds functionality)

## Why are we doing this? Any context or related work?

Just need Google models to work.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested, and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

Switch the character to use ModelProviderName.GOOGLE and ensure you have the API key for Gemini in your env:

GOOGLE_GENERATIVE_AI_API_KEY= # Gemini API key

Things should continue to run.
