### PR TITLE
fix: docs features darkmode color

### DIFF
--- a/docs/src/components/HomepageFeatures/index.js
+++ b/docs/src/components/HomepageFeatures/index.js
@@ -37,12 +37,15 @@ function Feature({ title, description }) {
     <div className={clsx("col col--4")}>
       <div className="card margin--md" style={{
         height: "100%",
-        backgroundColor: "rgba(255, 255, 255, 0.9)",
+        backgroundColor: "var(--ifm-card-background-color)",
         backdropFilter: "blur(10px)",
         borderRadius: "12px",
+        color: "var(--ifm-font-color-base)",
       }}>
         <div className="card__body text--center padding--md">
-          <Heading as="h3">{title}</Heading>
+          <Heading as="h3" style={{
+            color: "var(--ifm-heading-color)"
+          }}>{title}</Heading>
           <p>{description}</p>
         </div>
       </div>


### PR DESCRIPTION
# Relates to:

No Relation

# Risks

None

# Background

## What does this PR do?

It fixes the fucked up font in the Docs / GitHub pages when using Darkmode.
No rocket science.

Styling improvements:

* Changed the card background color to use the CSS variable `--ifm-card-background-color` instead of a fixed RGBA value.
* Added a CSS variable `--ifm-font-color-base` for the card text color.
* Updated the heading color to use the CSS variable `--ifm-heading-color`.

# Testing

## Detailed testing steps
Check out locally, cd into docs, run dev and looky looky

## Screenshots
### Before
<img width="1174" alt="Screenshot 2024-11-12 at 00 21 24" src="https://github.com/user-attachments/assets/32958352-50fc-4a85-8a2e-1f0640920ef8">

### After
<img width="1154" alt="Screenshot 2024-11-12 at 00 21 49" src="https://github.com/user-attachments/assets/acbb7146-4d4a-4882-a626-77cb4f2053fc">