### PR TITLE
Fix: compute unit increasein swapts, default is too low to make trans…

### DIFF
--- a/packages/plugin-solana/src/actions/swap.ts
+++ b/packages/plugin-solana/src/actions/swap.ts
@@ -76,7 +76,7 @@ async function swapToken(
             quoteResponse: quoteData,
             userPublicKey: walletPublicKey.toString(),
             wrapAndUnwrapSol: true,
-            computeUnitPriceMicroLamports: 1000,
+            computeUnitPriceMicroLamports: 2000000,
             dynamicComputeUnitLimit: true,
         };
 


### PR DESCRIPTION

<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

Swap.ts for solana swaps
# Risks

low

# Background
Solana swaps were failing due to very low compute, unit. With slight increase, the change of making succesfull transactions are higher.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.


# Testing

pnpm start
swap .00069 SOL So11111111111111111111111111111111111111112 for AI16Z HeLp6NuQkmYB4pYWo2zYs22mESHXPQYzXbB8n4V98jwC

<!--
None, automtated tests are fine.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deploy, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste commandline output. -->
<!--
## Database changes
-->

<!--  If there is something more than the automated steps, please specifiy deploy instructions. -->
<!--
## Deployment instructions
-->
