### PR TITLE
Don't blow up if the wallet is missing

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -223,7 +223,7 @@ export async function createAgent(
         plugins: [
             bootstrapPlugin,
             nodePlugin,
-            character.settings.secrets.WALLET_PUBLIC_KEY
+            character.settings.secrets?.WALLET_PUBLIC_KEY
                 ? solanaPlugin
                 : null
         ].filter(Boolean),


### PR DESCRIPTION
If settings is empty this blows up looking for the WALLET_PUBLIC_KEY, let's not do that

  "settings": {
    "secrets": {
      "WALLET_PUBLIC_KEY": "DM1fSD9KfdJ2jaSmR9NGpPPVcDzBwsYg1STttYc5Bvay"
    }
  },