### PR TITLE
[BE] Add script to dump all file contents into one file to interact with LLMs easier 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ characters/
 packages/core/src/providers/cache
 packages/core/src/providers/cache/*
 cache/*
+
+all_files_content.txt

--- a/dump_file_contents.sh
+++ b/dump_file_contents.sh
@@ -1,0 +1,35 @@
+#!/bin/zsh
+# Define the output file
+OUTPUT_FILE="all_files_content.txt"
+# Remove the output file if it already exists to start fresh
+if [[ -f "$OUTPUT_FILE" ]]; then
+    rm "$OUTPUT_FILE"
+fi
+# Start the find command, excluding the output file and hidden files
+FIND_CMD="find . -type f ! -name \"$OUTPUT_FILE\" ! -path '*/\.*'"
+# Loop through command-line arguments to add exclusions for file extensions, specific files, or directories
+for arg in "$@"; do
+    if [[ "$arg" == \.* ]]; then
+        # If the argument is a file extension, exclude files with that extension
+        FIND_CMD+=" ! -iname '*$arg'"
+    elif [[ -d "$arg" ]]; then
+        # If the argument is a directory, exclude it and its contents
+        FIND_CMD+=" ! -path './$arg/*'"
+    elif [[ -f "$arg" ]]; then
+        # If the argument is a file, exclude it
+        FIND_CMD+=" ! -name '$arg'"
+    else
+        # If the argument is a wildcard pattern, exclude matching files
+        FIND_CMD+=" ! -name '$arg'"
+    fi
+done
+# Execute the constructed find command and process files
+eval $FIND_CMD | while IFS= read -r file; do
+    # Append the file name and its content to the output file with separators
+    echo "---" >> "$OUTPUT_FILE"
+    echo "$file" >> "$OUTPUT_FILE"
+    echo "---" >> "$OUTPUT_FILE"
+    cat "$file" >> "$OUTPUT_FILE"
+    echo "\n\n" >> "$OUTPUT_FILE"
+done
+echo "All contents have been written to $OUTPUT_FILE"


### PR DESCRIPTION
# Relates to:

Better Engineering work as trying to contribute most effectively to the codebase using LLMs to consult and debug. 

# Risks

Low 

# Background

## What does this PR do?

This makes it trivial to work with LLMs for code gen / debugging by copy and pasting the contents of all_files_contents.txt


## What kind of change is this?

Improvements (misc. changes to existing features)

In order to make dev efficiency higher.


# Documentation changes needed?

If a docs change is needed: I have updated the documentation accordingly.


# Testing


## Where should a reviewer start?

## Detailed testing steps

Run script 

./dump_file_contents.sh folder_to_exclude folder_exclude 

Example
./dump_file_contents.sh packages .github .gitignore

<img width="1056" alt="Screenshot 2024-11-12 at 6 37 16 PM" src="https://github.com/user-attachments/assets/9d07169e-7d9f-46ba-adbb-b8de8e19cec5">


