### PR TITLE
Added missing GROK model provider key initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ characters/
 packages/core/src/providers/cache
 packages/core/src/providers/cache/*
 cache/*
+packages/core/cache/*

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -145,6 +145,11 @@ export function getTokenForProvider(
                 character.settings?.secrets?.OPENROUTER ||
                 settings.OPENROUTER_API_KEY
             );
+        case ModelProviderName.GROK:
+            return (
+                character.settings?.secrets?.GROK_API_KEY ||
+                settings.GROK_API_KEY
+            );
     }
 }
 
@@ -223,9 +228,7 @@ export async function createAgent(
         plugins: [
             bootstrapPlugin,
             nodePlugin,
-            character.settings.secrets?.WALLET_PUBLIC_KEY
-                ? solanaPlugin
-                : null
+            character.settings.secrets?.WALLET_PUBLIC_KEY ? solanaPlugin : null,
         ].filter(Boolean),
         providers: [],
         actions: [],


### PR DESCRIPTION
# Relates to:

#295

# Risks

**Low:** This change is low risk, as it only introduces a new case for an additional model provider in an existing switch statement. 

# Background

## What does this PR do?

This PR adds initialization for the `GROK` model provider key in the `getTokenForProvider` function. Previously, the function did not handle the `GROK` model provider, potentially leading to issues if the provider was selected without a corresponding key.

## What kind of change is this?

- **Feature:** This is a non-breaking change that adds functionality by supporting a new model provider (`GROK`).

# Documentation changes needed?

Yes

# Testing

## Where should a reviewer start?

The review should focus on the `getTokenForProvider` function in the relevant file, ensuring that the added `GROK` case aligns with the structure of other model provider cases.

## Detailed testing steps

- Confirm that selecting `ModelProviderName.GROK` successfully returns the appropriate API key from `character.settings?.secrets?.GROK_API_KEY` or `settings.GROK_API_KEY`.


# Deploy Notes

No special deployment instructions.

## Database changes

None.

## Deployment instructions

Standard deployment steps apply.