### PR TITLE
add node version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 **Prerequisites (MUST):**
     
 -   [Python 2.7+](https://www.python.org/downloads/)
--   [Node.js 22+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+-   [Node.js 23.1+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 -   [pnpm](https://pnpm.io/installation)
 
 ### Edit the .env file

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,7 +23,7 @@
 
 **前置要求（必须）:**
 
--   [Node.js 22+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+-   [Node.js 23+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 -   Nodejs安装
 -   [pnpm](https://pnpm.io/installation)
 -   使用pnpm

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ _As seen powering [@DegenSpartanAI](https://x.com/degenspartanai) and [@MarcAInd
 
 **Prerequisites (MUST):**
 
-- [Node.js 22+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- [Node.js 23+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - [pnpm](https://pnpm.io/installation)
 
 ### Edit the .env file

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -23,7 +23,7 @@
 
 **前置要求（必须）:**
 
-- [Node.js 22+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- [Node.js 23+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - Nodejs安装
 - [pnpm](https://pnpm.io/installation)
 - 使用pnpm

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         }
     },
     "engines": {
-        "node": ">=22"
+        "node": ">=23"
     },
     "dependencies": {
         "ollama-ai-provider": "^0.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10461,8 +10461,8 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
-  streamx@2.20.1:
-    resolution: {integrity: sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==}
+  streamx@2.20.2:
+    resolution: {integrity: sha512-aDGDLU+j9tJcUdPGOaHmVF1u/hhI+CsGkT02V3OKlHDV7IukOI+nTWAGkiZEKCO35rWN1wIr4tS7YFr1f4qSvA==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -16797,7 +16797,7 @@ snapshots:
 
   bare-stream@2.3.2:
     dependencies:
-      streamx: 2.20.1
+      streamx: 2.20.2
     optional: true
 
   base-x@3.0.10:
@@ -24231,7 +24231,7 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
-  streamx@2.20.1:
+  streamx@2.20.2:
     dependencies:
       fast-fifo: 1.3.2
       queue-tick: 1.0.1
@@ -24444,7 +24444,7 @@ snapshots:
     dependencies:
       b4a: 1.6.7
       fast-fifo: 1.3.2
-      streamx: 2.20.1
+      streamx: 2.20.2
 
   tar@6.2.1:
     dependencies:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Check Node.js version
+REQUIRED_NODE_VERSION=23
+CURRENT_NODE_VERSION=$(node -v | cut -d'.' -f1 | sed 's/v//')
+
+if (( CURRENT_NODE_VERSION < REQUIRED_NODE_VERSION )); then
+    echo "Error: Node.js version must be $REQUIRED_NODE_VERSION or higher. Current version is $CURRENT_NODE_VERSION."
+    exit 1
+fi
+
 # Navigate to the script's directory
 cd "$(dirname "$0")"/..
 


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

https://github.com/ai16z/eliza/issues/269 


# Risks

Low

# Background

Currently the build processes continues even if the node version is less than 23 or not, which can confuse some developers trying to build, keeping in mind the warning thrown by the default node env is very minimal.

## What does this PR do?

This PR aims to explicitly checks for node version and throws error during the build pro

## What kind of change is this?

Improvement to exisitng build flow

<!-- This "Why" section is most relevant if there is no linked issue explaining why. If there is a related issue it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

I have updated the documentation accordingly to match the required node version. 

# Testing

## Where should a reviewer start?

Just run the `pnpm build` cmd with node version less than `23` and greater than `23` 
