### PR TITLE
image gen saves file & returns format for clients; discord image poasting just works

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 
+#USE IMAGE GEN
+IMAGE_GEN= #TRUE
+
 #Leave blank to use local embeddings 
 USE_OPENAI_EMBEDDING=  #TRUE
 

--- a/packages/client-discord/src/index.ts
+++ b/packages/client-discord/src/index.ts
@@ -73,6 +73,7 @@ export class DiscordClient extends EventEmitter {
         this.runtime.registerAction(transcribe_media);
         this.runtime.registerAction(download_media);
 
+
         this.runtime.providers.push(channelStateProvider);
         this.runtime.providers.push(voiceStateProvider);
     }

--- a/packages/client-telegram/src/index.ts
+++ b/packages/client-telegram/src/index.ts
@@ -6,6 +6,7 @@ export const TelegramClientInterface: Client = {
     start: async (runtime: IAgentRuntime) => {
         const botToken = runtime.getSetting("TELEGRAM_BOT_TOKEN");
         const tg = new TelegramClient(runtime, botToken);
+        await tg.start();
         elizaLogger.success(
             `✅ Telegram client successfully started for character ${runtime.character.name}`
         );


### PR DESCRIPTION
image gen does not return caption or description anymore (not really needed)
it generates image & returns the path to image in context
this will allow discord to poast image
other clients need updated handle & sends
-tg _shouldRespond & action context adding never even called
-tg agent wasnt even starting (fixed this on main)
-will look into twitter client as well