### PR TITLE
fix: ensure unique instances for each Service subclass using Map

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -503,15 +503,17 @@ export interface IMemoryManager {
 }
 
 export abstract class Service {
-    private static instance: Service | null = null;
+    private static instances: Map<any, Service> = new Map();
     static serviceType: ServiceType;
 
     public static getInstance<T extends Service>(): T {
-        if (!Service.instance) {
-            // Use this.prototype.constructor to instantiate the concrete class
-            Service.instance = new (this as any)();
+        if (!Service.instances.has(this)) {
+            Service.instances.set(
+                this,
+                new (this as unknown as { new (): T })()
+            );
         }
-        return Service.instance as T;
+        return Service.instances.get(this) as T;
     }
 }
 


### PR DESCRIPTION
Previously, the Service base class used a single static instance, which caused
all subclasses to share the same instance. This update replaces the static
instance with a Map to manage unique instances for each subclass