### PR TITLE
added clientConfig to optionally ignore bots and DMs

### DIFF
--- a/packages/client-telegram/src/messageManager.ts
+++ b/packages/client-telegram/src/messageManager.ts
@@ -318,10 +318,20 @@ export class MessageManager {
             return; // Exit if no message or sender info
         }
 
-        // TODO: Handle commands?
-        // if (ctx.message.text?.startsWith("/")) {
-        //     return;
-        // }
+        if (
+            this.runtime.character.clientConfig?.telegram
+                ?.shouldIgnoreBotMessages &&
+            ctx.from.is_bot
+        ) {
+            return;
+        }
+        if (
+            this.runtime.character.clientConfig?.telegram
+                ?.shouldIgnoreDirectMessages &&
+            ctx.chat?.type === "private"
+        ) {
+            return;
+        }
 
         const message = ctx.message;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -352,6 +352,16 @@ export type Character = {
         model?: string;
         embeddingModel?: string;
     };
+    clientConfig?: {
+        discord?: {
+            shouldIgnoreBotMessages?: boolean;
+            shouldIgnoreDirectMessages?: boolean;
+        };
+        telegram?: {
+            shouldIgnoreBotMessages?: boolean;
+            shouldIgnoreDirectMessages?: boolean;
+        };
+    };
     style: {
         all: string[];
         chat: string[];


### PR DESCRIPTION
# Risks
Low to none

# Background

## What does this PR do?
Adds clientConfig to Character type and handle ignore DM and ignore bots logic in Telegram & Discord clients

## What kind of change is this?
An improvement to prevent abuse

## Why are we doing this? Any context or related work?
Bots keep draining each other's credits in #the-arena. On Telegram, they are also affected by buy bots etc. I think "ignoreBots" configuration option is needed. DMs are also a concern because it's easy to purchase Telegram/Discord accounts and drain anyone's credits. The "[IGNORE]" feature alone is not a sufficient solution. 

# Testing
Add
`"clientConfig": {
        "discord": {
            "shouldIgnoreBotMessages": true,
            "shouldIgnoreDirectMessages": true
        },
        "telegram": {
            "shouldIgnoreBotMessages": true,
            "shouldIgnoreDirectMessages": true
        }
}` to character.json file. All fields are optional. 