### PR TITLE
fix: openrouter 70b don't support 128000, changed to 405b in model.ts

### DIFF
--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -178,7 +178,7 @@ export const models: Models = {
             [ModelClass.SMALL]:
                 settings.SMALL_OPENROUTER_MODEL ||
                 settings.OPENROUTER_MODEL ||
-                "nousresearch/hermes-3-llama-3.1-70b",
+                "nousresearch/hermes-3-llama-3.1-405b",
             [ModelClass.MEDIUM]:
                 settings.MEDIUM_OPENROUTER_MODEL ||
                 settings.OPENROUTER_MODEL ||


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:
Openrouter 70b model token limit is lower than what we want to send, which end up throwing errors from API.
 Lowering token limit makes outputs less quality, instead we upgraded small model to 405b in model.ts
<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section is to be filled out before final review and merge. -->

# Risks

low

## What does this PR do?
Upgraded openrouter small model to 405b
## What kind of change is this?

bug fix


# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested, and probably help the PR get merged quicker. -->

# Testing
set Modelprovider to openrouter in character.json
pnpm start
