### PR TITLE
feat: adding back the renovate file for automated security scanning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+      "config:base"
+    ],
+    "packageRules": [
+      {
+        "groupName": "Discord.js ecosystem",
+        "matchPackagePatterns": [
+          "^@discordjs/",
+          "^discord.js"
+        ]
+      },
+      {
+        "groupName": "TypeScript and related",
+        "matchPackagePatterns": [
+          "^@typescript-eslint/",
+          "^typescript$",
+          "^ts-",
+          "^tslib$"
+        ]
+      },
+      {
+        "groupName": "Testing frameworks",
+        "matchPackagePatterns": [
+          "^jest$",
+          "^@types/jest$"
+        ]
+      },
+      {
+        "groupName": "Rollup and plugins",
+        "matchPackagePatterns": [
+          "^@rollup/",
+          "^rollup"
+        ]
+      },
+      {
+        "groupName": "ESLint and formatting",
+        "matchPackagePatterns": [
+          "^eslint",
+          "^prettier"
+        ]
+      },
+      {
+        "groupName": "SQLite related",
+        "matchPackagePatterns": [
+          "sqlite",
+          "^@types/better-sqlite3",
+          "^@types/sql.js"
+        ]
+      },
+      {
+        "groupName": "AI/ML packages",
+        "matchPackagePatterns": [
+          "^@anthropic-ai/",
+          "^@huggingface/",
+          "^openai$",
+          "^tiktoken$"
+        ]
+      },
+      {
+        "groupName": "Audio processing",
+        "matchPackagePatterns": [
+          "^wav",
+          "^@discordjs/opus",
+          "^fluent-ffmpeg",
+          "^ffmpeg",
+          "^@types/wav"
+        ]
+      },
+      {
+        "groupName": "Solana packages",
+        "matchPackagePatterns": [
+          "^@solana/"
+        ]
+      }
+    ],
+    "timezone": "UTC",
+    "schedule": ["every weekend"],
+    "prHourlyLimit": 2,
+    "prConcurrentLimit": 10,
+    "rangeStrategy": "pin",
+    "separateMajorMinor": true,
+    "dependencyDashboard": true
+  }


### PR DESCRIPTION
# Relates to: #79

The Renovate file was removed somewhere along the lines which helps us do automated security scanning and package dependency updates. This adds it back into the dev branch.

# Risks

Low

# Background

## What does this PR do?

## What kind of change is this?

Improvements (misc. changes to existing features)

