### PR TITLE
update tweet interval to 90-180 mins

### DIFF
--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -33,8 +33,8 @@ export class TwitterPostClient extends ClientBase {
             this.generateNewTweet();
             setTimeout(
                 generateNewTweetLoop,
-                (Math.floor(Math.random() * (4 - 1 + 1)) + 1) * 60 * 60 * 1000
-            ); // Random interval between 1 and 4 hours
+                (Math.floor(Math.random() * (180 - 90 + 1)) + 90) * 60 * 1000
+            ); // Random interval: min 90min/max 180min (1.5-3h), Results in min 8/max 16 posts per day
         };
         // setTimeout(() => {
         generateNewTweetLoop();


### PR DESCRIPTION
# Adjust tweet interval randomization

## Summary
Adjusts existing randomized posting interval from 1-4 hours to 90-180 minutes (1.5-3 hours) to help with account restrictions until better solution is implemented.

## Changes
- Modified existing interval in `generateNewTweetLoop` from 1-4 hours to 90-180 minutes
- Updated interval calculation: `(Math.floor(Math.random() * (180 - 90 + 1)) + 90) * 60 * 1000`
- Changes posting range from 6-24 to 8-16 posts per day

## Context
This adjustment helps better align with Twitter's usage patterns and provides more consistent posting frequency. A more sophisticated system could be considered that:
- Could support configurable posting patterns (uniform, normal, life-cycle based)
- Could allow custom range settings
- Could include rate limit handling
- Could add more natural posting behaviors

## Testing
- Verified interval generation stays within 90-180 minute range
- Tested loop continuation

This provides a baseline that respects platform usage patterns.