### PR TITLE
fix: ca for btc was spam/fake

### DIFF
--- a/packages/plugin-solana/src/providers/wallet.ts
+++ b/packages/plugin-solana/src/providers/wallet.ts
@@ -10,7 +10,7 @@ const PROVIDER_CONFIG = {
     DEFAULT_RPC: "https://api.mainnet-beta.solana.com",
     TOKEN_ADDRESSES: {
         SOL: "So11111111111111111111111111111111111111112",
-        BTC: "qfnqNqs3nCAHjnyCgLRDbBtq4p2MtHZxw8YjSyYhPoL",
+        BTC: "3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh",
         ETH: "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
     },
 };


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

The CA of BTC was fake/wrong one. Changed it to correct address 

Previous Address = https://birdeye.so/token/qfnqNqs3nCAHjnyCgLRDbBtq4p2MtHZxw8YjSyYhPoL?chain=solana

New Address = https://birdeye.so/token/3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh


# Risks

High

# Background

## What does this PR do?

Changed the CA

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)