### PR TITLE
Register memory managers if passed to runtime

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -252,6 +252,10 @@ export class AgentRuntime implements IAgentRuntime {
             tableName: "fragments",
         });
 
+        (opts.managers ?? []).forEach((manager: IMemoryManager) => {
+            this.registerMemoryManager(manager);
+        });
+
         (opts.services ?? []).forEach((service: Service) => {
             this.registerService(service);
         });


### PR DESCRIPTION
# Relates to:

<!-- Add link to related issue or ticket here if applicable -->

# Risks

Low. This change introduces a new feature to register memory managers, which should not affect existing functionality.

# Background

## What does this PR do?

This PR adds functionality to register memory managers if they are passed to the runtime. It iterates through the `managers` array in the `opts` object and calls `registerMemoryManager` for each manager.

## What kind of change is this?

Features (non-breaking change which adds functionality)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The reviewer should start by examining the `AgentRuntime` class in the `packages/core/src/runtime.ts` file, focusing on the new code block that registers memory managers.

## Detailed testing steps

- Verify that the `AgentRuntime` class correctly initializes with the new code block.
- Test passing an array of memory managers to the runtime options and ensure they are properly registered.
- Check that existing functionality remains unaffected by this change.
- Verify that the `registerMemoryManager` method is called for each manager in the array.

# Deploy Notes

No special deploy notes are required for this change.

Sources
