### PR TITLE
fix: don't continue to load if a specified file is not found

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -69,7 +69,6 @@ export async function loadCharacters(
             }
             return path;
         });
-
     const loadedCharacters = [];
 
     if (characterPaths?.length > 0) {
@@ -96,6 +95,8 @@ export async function loadCharacters(
                 loadedCharacters.push(character);
             } catch (e) {
                 console.error(`Error loading character from ${path}: ${e}`);
+                // don't continue to load if a specified file is not found
+                process.exit(1)
             }
         }
     }


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

If you specify a file to load, don't just load default and continue if you can't find it

## What kind of change is this?

UX clean up, should reduce confusion and reduce support issues

## Why are we doing this? Any context or related work?

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

I tested on stable-11-17 branch

