### PR TITLE
feat: don't require .env to exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@
 
 ### Edit the .env file
 
-Copy .env.example to .env and fill in the appropriate values
+Copy .env.example to .env and fill in the appropriate values.
 
 ```
 cp .env.example .env
 ```
+
+Note: .env is optional. If your planning to run multiple distinct agents, you can pass secrets through the character JSON
 
 ### Automatically Start Eliza
 

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -69,18 +69,12 @@ export function loadEnvConfig(): Settings {
     // Node.js environment: load from .env file
     const envPath = findNearestEnvFile();
 
-    if (!envPath) {
-        throw new Error("No .env file found in current or parent directories.");
+    // attempt to Load the .env file into process.env
+    const result = config(envPath ? { path: envPath } : {});
+
+    if (!result.error) {
+        console.log(`Loaded .env file from: ${envPath}`);
     }
-
-    // Load the .env file
-    const result = config({ path: envPath });
-
-    if (result.error) {
-        throw new Error(`Error loading .env file: ${result.error}`);
-    }
-
-    console.log(`Loaded .env file from: ${envPath}`);
     return process.env as Settings;
 }
 


### PR DESCRIPTION
# Risks

Medium, haven't discussed this widely

# Background

## What does this PR do?

Removes the requirement for .env to exists

## What kind of change is this?

Improvement

## Why are we doing this? Any context or related work?

Large multiagent instances will have to rely on character.json to have all the settings and secrets for that agent. Have a default .env in these instances to set defaults might be helpful but also hurtful. This allows the admin to choose if they want any defaults across all their agents or nots.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

Ran against stable-11-17 branch without issue