### PR TITLE
fix: since agent is moved out of packages, adjust default path

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -58,16 +58,9 @@ export async function loadCharacters(
         ?.split(",")
         .map((path) => path.trim())
         .map((path) => {
-            if (path.startsWith("../characters")) {
-                return `../${path}`;
-            }
-            if (path.startsWith("characters")) {
-                return `../../${path}`;
-            }
-            if (path.startsWith("./characters")) {
-                return `../.${path}`;
-            }
-            return path;
+          if (path[0] === '/') return path; // handle absolute paths
+          // assume relative to the project root where pnpm is ran
+          return `../${path}`;
         });
     const loadedCharacters = [];
 


### PR DESCRIPTION
# Risks

Medium, may affect npm packaging

# Background

## What does this PR do?

fixes
`Error loading character from ../../characters/trump.character.json: Error: ENOENT: no such file or directory, open '../../characters/trump.character.json'`
when running it like
`pnpm start --characters="characters/trump.character.json" from the repo on 0.1.1`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Loaf asked

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

I ran a quick test