### PR TITLE
fix: The bot is by default deafened and we don't want that

### DIFF
--- a/packages/client-discord/src/actions/joinvoice.ts
+++ b/packages/client-discord/src/actions/joinvoice.ts
@@ -1,6 +1,11 @@
 // @ts-nocheck
 // src/actions/joinVoice
-import { joinVoiceChannel } from "@discordjs/voice";
+import {
+    Action,
+    ActionExample, composeContext, IAgentRuntime,
+    Memory,
+    State
+} from "@ai16z/eliza";
 import {
     Channel,
     ChannelType,
@@ -9,14 +14,6 @@ import {
     Guild,
     GuildMember,
 } from "discord.js";
-import { composeContext } from "@ai16z/eliza";
-import {
-    Action,
-    ActionExample,
-    IAgentRuntime,
-    Memory,
-    State,
-} from "@ai16z/eliza";
 
 export default {
     name: "JOIN_VOICE",
@@ -115,8 +112,15 @@ export default {
             );
         });
 
+        if (!state.voiceManager) {
+            state.voiceManager = new VoiceManager({
+                client: state.discordClient,
+                runtime: runtime,
+            });
+        }
+
         if (targetChannel) {
-            joinVoiceChannel({
+            state.voiceManager.joinVoiceChannel({
                 channelId: targetChannel.id,
                 guildId: (discordMessage as DiscordMessage).guild?.id as string,
                 adapterCreator: (client.guilds.cache.get(id) as Guild)
@@ -127,7 +131,7 @@ export default {
             const member = (discordMessage as DiscordMessage)
                 .member as GuildMember;
             if (member?.voice?.channel) {
-                joinVoiceChannel({
+                state.voiceManager.joinVoiceChannel({
                     channelId: member.voice.channel.id,
                     guildId: (discordMessage as DiscordMessage).guild
                         ?.id as string,
@@ -197,7 +201,7 @@ You should only respond with the name of the voice channel or none, no commentar
                 });
 
                 if (targetChannel) {
-                    joinVoiceChannel({
+                    state.voiceManager.joinVoiceChannel({
                         channelId: targetChannel.id,
                         guildId: (discordMessage as DiscordMessage).guild
                             ?.id as string,

--- a/packages/client-discord/src/voice.ts
+++ b/packages/client-discord/src/voice.ts
@@ -1,4 +1,16 @@
 import {
+    Content,
+    HandlerCallback,
+    IAgentRuntime,
+    ISpeechService,
+    ITranscriptionService,
+    Memory,
+    ModelClass,
+    ServiceType,
+    State,
+    UUID, composeContext, elizaLogger, embeddingZeroVector, generateMessageResponse, messageCompletionFooter, stringToUuid
+} from "@ai16z/eliza";
+import {
     AudioReceiveStream,
     NoSubscriberBehavior,
     StreamType,
@@ -20,23 +32,6 @@ import {
 import EventEmitter from "events";
 import prism from "prism-media";
 import { Readable, pipeline } from "stream";
-import { composeContext, elizaLogger } from "@ai16z/eliza";
-import { generateMessageResponse } from "@ai16z/eliza";
-import { embeddingZeroVector } from "@ai16z/eliza";
-import {
-    Content,
-    HandlerCallback,
-    IAgentRuntime,
-    ISpeechService,
-    ITranscriptionService,
-    Memory,
-    ModelClass,
-    ServiceType,
-    State,
-    UUID,
-} from "@ai16z/eliza";
-import { stringToUuid } from "@ai16z/eliza";
-import { messageCompletionFooter } from "@ai16z/eliza";
 import { DiscordClient } from "./index.ts";
 
 export function getWavHeader(
@@ -222,6 +217,9 @@ export class VoiceManager extends EventEmitter {
         if (oldConnection) {
             try {
                 oldConnection.destroy();
+                // Remove all associated streams and monitors
+                this.streams.clear();
+                this.activeMonitors.clear();
             } catch (error) {
                 console.error("Error leaving voice channel:", error);
             }
@@ -234,11 +232,22 @@ export class VoiceManager extends EventEmitter {
             selfMute: false,
         });
 
+        // Explicitly undeafen and unmute the bot
+        const me = channel.guild.members.me;
+        if (me?.voice) {
+            await me.voice.setDeaf(false);
+            await me.voice.setMute(false);
+        }
+
         for (const [, member] of channel.members) {
             if (!member.user.bot) {
                 this.monitorMember(member, channel);
             }
         }
+
+        connection.on('error', (error) => {
+            console.error('Voice connection error:', error);
+        });
 
         connection.receiver.speaking.on("start", (userId: string) => {
             const user = channel.members.get(userId);


### PR DESCRIPTION
# Relates to:
(No linked issue provided in the diff)

# Risks
Low - Changes only affect voice channel behavior for the Discord bot, specifically its deafened/muted state when joining channels.

# Background
## What does this PR do?
This PR fixes an issue where the Discord bot was joining voice channels in a deafened state by default. The changes include:
1. Explicitly setting the bot to undeafened and unmuted when joining voice channels
2. Improved voice connection cleanup by clearing streams and monitors when destroying old connections
3. Added error handling for voice connections
4. Refactored voice channel join logic to use VoiceManager instead of direct joinVoiceChannel calls

## What kind of change is this?
Bug fix (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
1. Review the changes in `packages/client-discord/src/actions/joinvoice.ts` where joinVoiceChannel calls are replaced with state.voiceManager
2. Check the new voice connection setup in `packages/client-discord/src/voice.ts`

## Detailed testing steps
1. As a user, invite the bot to a Discord server
2. Join a voice channel
3. Make the bot join the same voice channel
4. Verify that:
   - The bot joins successfully
   - The bot is not deafened by default
   - The bot is not muted by default
   - The bot can properly hear and process voice input from users

The automated tests should be updated to verify this behaviour remains consistent.