### PR TITLE
fix: ignored modelEndpointOverride in generation

### DIFF
--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -1035,7 +1035,8 @@ async function handleOpenAI({
     mode,
     modelOptions,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
-    const openai = createOpenAI({ apiKey, baseURL: models.openai.endpoint });
+    const baseURL = models.openai.endpoint || undefined
+    const openai = createOpenAI({ apiKey, baseURL });
     return await aiGenerateObject({
         model: openai.languageModel(model),
         schema,

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -1035,7 +1035,7 @@ async function handleOpenAI({
     mode,
     modelOptions,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
-    const openai = createOpenAI({ apiKey });
+    const openai = createOpenAI({ apiKey, baseURL: models.openai.endpoint });
     return await aiGenerateObject({
         model: openai.languageModel(model),
         schema,


### PR DESCRIPTION
# Background

## What does this PR do?

This PR fixes the issue of OpenAi object initialization which ignores the `modelEndpointOverride` optioin of the character

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)
