### PR TITLE
bugfix: Modify docker run error after agent folder move

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -23,6 +23,7 @@ case "$1" in
         BASE_MOUNTS=(
             "characters:/app/characters"
             ".env:/app/.env"
+            "agent:/app/agent"
             "docs:/app/docs"
             "scripts:/app/scripts"
         )
@@ -33,7 +34,6 @@ case "$1" in
             "adapter-sqlite"
             "adapter-sqljs"
             "adapter-supabase"
-            "agent"
             "client-auto"
             "client-direct"
             "client-discord"


### PR DESCRIPTION
# Relates to:

Docker running error


# Risks

Low, The scope of influence is the operation of docker


# Background

## What does this PR do?

After the author moved the agent folder, docker could not map the agent directory in docker, so docker volumn mapping incorrectly. I re-mapped the agent directory

docker has the following error:
```
sudo docker compose -f docker-compose-waifu.yaml up
[+] Running 1/0
✔ Container waifu  Created                                                                                               0.0 s
Attaching to waifu
waifu  |
waifu  | &gt;  eliza@ start /app
waifu  | &gt;  pnpm --filter "@ai16z/agent" start --isRoot "--characters=characters/waifu.character.json"
waifu  |
waifu  | No projects matched the filters in "/app"
```

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)


# Documentation changes needed?

My changes do not require a change to the project documentation.


# Testing

## Where should a reviewer start?

Carry out
```
. ./scripts/docker.sh build
. ./scripts/docker.sh run
```
Try to see if the docker log is error free