### PR TITLE
feat: Added TWITTER_COOKIE example on quickstart.md

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -136,6 +136,16 @@ TWITTER_EMAIL=    # Account email
 TWITTER_COOKIES=  # Account cookies (auth_token and CT0)
 ```
 
+Example for TWITTER_COOKIES
+
+The TWITTER_COOKIES variable should be a JSON string containing the necessary cookies. You can find these cookies in your web browser's developer tools. Here is an example format:
+
+```bash
+TWITTER_COOKIES='[{"name":"auth_token","value":"your token","domain":".twitter.com"},
+  {"name":"ct0","value":"your ct0","domain":".twitter.com"},
+  {"name":"guest_id","value":"your guest_id","domain":".twitter.com"}]'
+```
+
 ### Telegram Bot
 
 1. Create a bot


### PR DESCRIPTION
# Background

## What does this PR do?

For the Twitter-related `.env` file, `TWITTER_COOKIES` requires a specific JSON format with relevant information. Without an example, new developers may have difficulty configuring the Twitter environment.

## What kind of change is this?

Added an example for `TWITTER_COOKIES`.

