### PR TITLE
add template types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -335,7 +335,21 @@ export type Character = {
     modelProvider: ModelProviderName;
     modelEndpointOverride?: string;
     templates?: {
-        [key: string]: string;
+        goalsTemplate?: string;
+        factsTemplate?: string;
+        messageHandlerTemplate?: string;
+        shouldRespondTemplate?: string;
+        continueMessageHandlerTemplate?: string;
+        evaluationTemplate?: string;
+        twitterSearchTemplate?: string;
+        twitterPostTemplate?: string;
+        twitterMessageHandlerTemplate?: string;
+        twitterShouldRespondTemplate?: string;
+        telegramMessageHandlerTemplate?: string;
+        telegramShouldRespondTemplate?: string;
+        discordVoiceHandlerTemplate?: string;
+        discordShouldRespondTemplate?: string;
+        discordMessageHandlerTemplate?: string;
     };
     bio: string | string[];
     lore: string[];


### PR DESCRIPTION
# Risks
Low. Default templates already exist so this change won't crash anyone's bot.

## What does this PR do?
Improving "templates" of Character type

## Why are we doing this? Any context or related work?
[key: string] is too broad and making it difficult to track which keywords are being used to override default templates. 