### PR TITLE
Wrap `fastembed` in try catch to allow non node environments to build

### DIFF
--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -143,7 +143,7 @@ async function getLocalEmbedding(input: string): Promise<number[]> {
                 try {
                     return await import("fastembed");
                 } catch (error) {
-                    elizaLogger.error("Failed to load fastembed,");
+                    elizaLogger.error("Failed to load fastembed.");
                     throw new Error("fastembed import failed, falling back to remote embedding");
                 }
             })()
@@ -178,7 +178,7 @@ async function getLocalEmbedding(input: string): Promise<number[]> {
         const embedding = await embeddingModel.queryEmbed(trimmedInput);
         return embedding;
     } catch (error) {
-		elizaLogger.warn("Local embedding not supported in browser, falling back to remote embedding:", error);
+		elizaLogger.warn("Local embedding not supported in browser, falling back to remote embedding.");
         throw new Error("Local embedding not supported in browser");
     }
 }

--- a/packages/core/src/embedding.ts
+++ b/packages/core/src/embedding.ts
@@ -143,7 +143,7 @@ async function getLocalEmbedding(input: string): Promise<number[]> {
                 try {
                     return await import("fastembed");
                 } catch (error) {
-                    elizaLogger.error("Failed to load fastembed:", error);
+                    elizaLogger.error("Failed to load fastembed,");
                     throw new Error("fastembed import failed, falling back to remote embedding");
                 }
             })()


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to: https://github.com/ai16z/eliza/issues/507

Non node.js environments may have issues building because of some packages and how they are imported.

##To Reproduce

Make a worker, include eliza/core and attempt to build. It will throw an error similar to

  ✘ [ERROR] No loader is configured for ".node" files:
  node_modules/@anush008/tokenizers-darwin-universal/tokenizers.darwin-universal.node

      node_modules/@anush008/tokenizers/index.js:116:32:
        116 │ ... nativeBinding = require('@anush008/tokenizers-darwin-universal')
Expected behavior

<img width="653" alt="image" src="https://github.com/user-attachments/assets/612b7cf1-0a04-4a0d-84ec-840811e4ca8d">


This PR wraps the import in try catch to gracefully fail and allow the build. 