### PR TITLE
fix: Use BigInt for tweet IDs in client-twitter

### DIFF
--- a/packages/client-twitter/src/base.ts
+++ b/packages/client-twitter/src/base.ts
@@ -86,7 +86,7 @@ export class ClientBase extends EventEmitter {
     twitterClient: Scraper;
     runtime: IAgentRuntime;
     directions: string;
-    lastCheckedTweetId: number | null = null;
+    lastCheckedTweetId: bigint | null = null;
     imageDescriptionService: IImageDescriptionService;
     temperature: number = 0.5;
 
@@ -588,12 +588,12 @@ export class ClientBase extends EventEmitter {
 
     async loadLatestCheckedTweetId(): Promise<void> {
         const latestCheckedTweetId =
-            await this.runtime.cacheManager.get<number>(
+            await this.runtime.cacheManager.get<string>(
                 `twitter/${this.profile.username}/latest_checked_tweet_id`
             );
 
         if (latestCheckedTweetId) {
-            this.lastCheckedTweetId = latestCheckedTweetId;
+            this.lastCheckedTweetId = BigInt(latestCheckedTweetId);
         }
     }
 
@@ -601,7 +601,7 @@ export class ClientBase extends EventEmitter {
         if (this.lastCheckedTweetId) {
             await this.runtime.cacheManager.set(
                 `twitter/${this.profile.username}/latest_checked_tweet_id`,
-                this.lastCheckedTweetId
+                this.lastCheckedTweetId.toString()
             );
         }
     }

--- a/packages/client-twitter/src/interactions.ts
+++ b/packages/client-twitter/src/interactions.ts
@@ -127,7 +127,7 @@ export class TwitterInteractionClient {
             for (const tweet of uniqueTweetCandidates) {
                 if (
                     !this.client.lastCheckedTweetId ||
-                    parseInt(tweet.id) > this.client.lastCheckedTweetId
+                    BigInt(tweet.id) > this.client.lastCheckedTweetId
                 ) {
                     elizaLogger.log("New Tweet found", tweet.permanentUrl);
 
@@ -167,7 +167,7 @@ export class TwitterInteractionClient {
                     });
 
                     // Update the last checked tweet ID after processing each tweet
-                    this.client.lastCheckedTweetId = parseInt(tweet.id);
+                    this.client.lastCheckedTweetId = BigInt(tweet.id);
                 }
             }
 


### PR DESCRIPTION
Tweet IDs are ranging beyond JS integer support

# Risks

Low. Should be a straight bug fix.

## What does this PR do?

Replaces the usage of `number` by `biting` to store the `lastCheckedTweetId` in the twitter client.

## What kind of change is this?

Bug fix

## Why are we doing this? Any context or related work?

Tweet IDs are in the range of 2^60, which is more than Javascript can safely handle.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

Running a twitter client will work but the numbers get silently rounded.
Steps:
- Run an agent with the twitter client. Log the values of `lastCheckedTweetId`.

