### PR TITLE
fix: remove postinstall script from plugin-coinbase

### DIFF
--- a/packages/plugin-coinbase/package.json
+++ b/packages/plugin-coinbase/package.json
@@ -13,8 +13,7 @@
     },
     "scripts": {
         "build": "tsup --format esm --dts",
-        "dev": "tsup --watch",
-        "postinstall": "npx playwright install-deps && npx playwright install"
+        "dev": "tsup --watch"
     },
     "peerDependencies": {
         "onnxruntime-node": "^1.20.0",


### PR DESCRIPTION
The plugin from coinbase doesnt use playwright this was probably copied from plugin-node