### PR TITLE
fix: discord crash on sending message to null channel

### DIFF
--- a/packages/client-discord/src/messages.ts
+++ b/packages/client-discord/src/messages.ts
@@ -261,6 +261,13 @@ function splitMessage(content: string): string[] {
 }
 
 function canSendMessage(channel) {
+    // validate input
+    if (!channel) {
+        return {
+            canSend: false,
+            reason: "No channel given",
+        }
+    }
     // if it is a DM channel, we can always send messages
     if (channel.type === ChannelType.DM) {
         return {
@@ -438,10 +445,11 @@ export class MessageManager {
                     this.client.user?.displayName,
             });
 
-            if (!canSendMessage(message.channel).canSend) {
+            const canSendResult = canSendMessage(message.channel)
+            if (!canSendResult.canSend) {
                 return elizaLogger.warn(
                     `Cannot send message to channel ${message.channel}`,
-                    canSendMessage(message.channel)
+                    canSendResult
                 );
             }
 


### PR DESCRIPTION
- canSendMessage guard
- don't call it twice in handleMessage

# Risks

Low

# Background

## What does this PR do?

Fixes

```
Error handling message: TypeError: Cannot read properties of null (reading 'type')
at canSendMessage (file:///root/edward/packages/client-discord/dist/index.js:1727:17)
at MessageManager.handleMessage (file:///root/edward/packages/client-discord/dist/index.js:1833:18)
node:events:485
throw er; // Unhandled 'error' event
^

TypeError: Cannot read properties of null (reading 'type')
at MessageManager.handleMessage (file:///root/edward/packages/client-discord/dist/index.js:1930:33)
Emitted 'error' event on Client instance at:
    at emitUnhandledRejectionOrErr (node:events:390:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:92:21)

Node.js v23.1.0
[nodemon] app crashed - waiting for file changes before starting...
```

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Minor improvement to increase stability

# Documentation changes needed?

My changes do not require a change to the project documentation.