### PR TITLE
fix: time prompt to include UTC, convert to verbose english to help prompting

### DIFF
--- a/packages/plugin-bootstrap/src/providers/time.ts
+++ b/packages/plugin-bootstrap/src/providers/time.ts
@@ -3,10 +3,19 @@ import { IAgentRuntime, Memory, Provider, State } from "@ai16z/eliza";
 const timeProvider: Provider = {
     get: async (_runtime: IAgentRuntime, _message: Memory, _state?: State) => {
         const currentDate = new Date();
-        const currentTime = currentDate.toLocaleTimeString("en-US");
-        const currentYear = currentDate.getFullYear();
-        return `The current time is: ${currentTime}, ${currentYear}`;
+
+        // Get UTC time since bots will be communicating with users around the global
+        const options = {
+            timeZone: "UTC",
+            dateStyle: "full" as "full",
+            timeStyle: "long" as "long",
+        };
+        const humanReadable = new Intl.DateTimeFormat("en-US", options).format(
+            currentDate
+        );
+
+        // The current date and time is Tuesday, November 26, 2024 at 3:17:32 AM UTC. Please use this as your reference for any time-based operations or responses.
+        return `The current date and time is ${humanReadable}. Please use this as your reference for any time-based operations or responses.`;
     },
 };
-
 export { timeProvider };


### PR DESCRIPTION
# Risks

Low
# Background

## What does this PR do?

Pass the time/date at GMT in english to the LLM, so it's not the timezone the server is in

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

So you can ask it what time is in specific time zones and it works (if you server's localtime is not set to UTC)

# Documentation changes needed?

My changes do not require a change to the project documentation.
