### PR TITLE
fix: use correct getCachedEmbeddings query_field_sub_name

### DIFF
--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -122,7 +122,7 @@ export class MemoryManager implements IMemoryManager {
             query_threshold: 2,
             query_input: content,
             query_field_name: "content",
-            query_field_sub_name: "content",
+            query_field_sub_name: "text",
             query_match_count: 10,
         });
     }


### PR DESCRIPTION
to get cached embeddings the db adapter looks for the sub_name of the memory content and the correct key is text not content.

```typescript
interface Content {
    /** The main text content */
    text: string;

    /** Optional action associated with the message */
    action?: string;

    /** Optional source/origin of the content */
    source?: string;

    /** URL of the original message/post (e.g. tweet URL, Discord message link) */
    url?: string;

    /** UUID of parent message if this is a reply/thread */
    inReplyTo?: UUID;

    /** Array of media attachments */
    attachments?: Media[];

    /** Additional dynamic properties */
    [key: string]: unknown;
}
```