### PR TITLE
fix: memory similarity log & new knowledge ingestion

### DIFF
--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -5,3 +5,4 @@
 *.env
 .env*
 /data
+/generatedImages

--- a/packages/core/src/knowledge.ts
+++ b/packages/core/src/knowledge.ts
@@ -23,7 +23,7 @@ async function get(runtime: AgentRuntime, message: Memory): Promise<KnowledgeIte
         ...new Set(
             fragments.map((memory) => {
                 elizaLogger.log(
-                    `Matched fragment: ${memory.content.text} with similarity: ${message.similarity}`
+                    `Matched fragment: ${memory.content.text} with similarity: ${memory.similarity}`
                 );
                 return memory.content.source;
             })

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -402,7 +402,7 @@ export class AgentRuntime implements IAgentRuntime {
             const existingDocument =
                 await this.documentsManager.getMemoryById(knowledgeId);
             if (existingDocument) {
-                return;
+                continue;
             }
 
             console.log(


### PR DESCRIPTION
# Relates to:

https://github.com/ai16z/eliza/issues/615
https://github.com/ai16z/eliza/issues/614

<!-- This risks section is to be filled out before final review and merge. -->

# Risks

Low:
- Change a `break;` to `continue;`
- Use the correct object in a logging statement
- Update .gitignore so the `generatedImages` folder doesn't get added to source control

# Background

## What does this PR do?

A couple of small changes:
1. Fix the issue where new knowledge entries in character profile don't get included in agents memory db.
2. Fix for memory fragment similarity score logging.
3. Updated gitignore in `/agent` to ignore generated images

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

To make changes to core knowledge work and log memory related search metrics correctly.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Screenshots and replication steps for 2 bugs described in the linked issues.

## Detailed testing steps

See linked issues

## Discord username

yoniebans
