### PR TITLE
fix: handle when tweet_results is empty better

### DIFF
--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -208,9 +208,12 @@ export class TwitterPostClient {
                         await this.client.twitterClient.sendTweet(content)
                 );
                 const body = await result.json();
+                if (!body?.data?.create_tweet?.tweet_results?.result) {
+                  console.error("Error sending tweet; Bad response:", body);
+                  return;
+                }
                 const tweetResult = body.data.create_tweet.tweet_results.result;
 
-                // console.dir({ tweetResult }, { depth: Infinity });
                 const tweet = {
                     id: tweetResult.rest_id,
                     name: this.client.profile.screenName,

--- a/packages/client-twitter/src/utils.ts
+++ b/packages/client-twitter/src/utils.ts
@@ -182,29 +182,33 @@ export async function sendTweet(
                     previousTweetId
                 )
         );
-        // Parse the response
         const body = await result.json();
-        const tweetResult = body.data.create_tweet.tweet_results.result;
 
-        const finalTweet: Tweet = {
-            id: tweetResult.rest_id,
-            text: tweetResult.legacy.full_text,
-            conversationId: tweetResult.legacy.conversation_id_str,
-            //createdAt:
-            timestamp: tweetResult.timestamp * 1000,
-            userId: tweetResult.legacy.user_id_str,
-            inReplyToStatusId: tweetResult.legacy.in_reply_to_status_id_str,
-            permanentUrl: `https://twitter.com/${twitterUsername}/status/${tweetResult.rest_id}`,
-            hashtags: [],
-            mentions: [],
-            photos: [],
-            thread: [],
-            urls: [],
-            videos: [],
-        };
-
-        sentTweets.push(finalTweet);
-        previousTweetId = finalTweet.id;
+        // if we have a response
+        if (body?.data?.create_tweet?.tweet_results?.result) {
+          // Parse the response
+          const tweetResult = body.data.create_tweet.tweet_results.result;
+          const finalTweet: Tweet = {
+              id: tweetResult.rest_id,
+              text: tweetResult.legacy.full_text,
+              conversationId: tweetResult.legacy.conversation_id_str,
+              //createdAt:
+              timestamp: tweetResult.timestamp * 1000,
+              userId: tweetResult.legacy.user_id_str,
+              inReplyToStatusId: tweetResult.legacy.in_reply_to_status_id_str,
+              permanentUrl: `https://twitter.com/${twitterUsername}/status/${tweetResult.rest_id}`,
+              hashtags: [],
+              mentions: [],
+              photos: [],
+              thread: [],
+              urls: [],
+              videos: [],
+          };
+          sentTweets.push(finalTweet);
+          previousTweetId = finalTweet.id;
+        } else {
+          console.error("Error sending chunk", chunk, "repsonse:", body);
+        }
 
         // Wait a bit between tweets to avoid rate limiting issues
         await wait(1000, 2000);


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

Fix

`["⛔ Error sending response tweet: TypeError: Cannot read properties of undefined (reading 'tweet_results')"]`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Better internal state validation to make system work as expected

# Documentation changes needed?

My changes do not require a change to the project documentation.