### PR TITLE
Wrong argument correction on trustScoreProvider.ts

### DIFF
--- a/packages/plugin-solana/src/providers/trustScoreProvider.ts
+++ b/packages/plugin-solana/src/providers/trustScoreProvider.ts
@@ -77,7 +77,7 @@ export class TrustScoreManager {
         this.backendToken = runtime.getSetting("BACKEND_TOKEN");
         this.simulationSellingService = new SimulationSellingService(
             runtime,
-            this.tokenProvider
+            this.trustScoreDb
         );
     }
 


### PR DESCRIPTION
SimulationSellingService accepts second param as turstScoreDb, not TokenProvider

# Risks

LARGE, It's not able to build the package

# Background

## What does this PR do?
Solve a bug.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
No need.

## Discord username
0xdexplorer
