### PR TITLE
feat: Add wallet history (transactions, balances) to coinbase providers

### DIFF
--- a/packages/plugin-coinbase/src/plugins/commerce.ts
+++ b/packages/plugin-coinbase/src/plugins/commerce.ts
@@ -15,6 +15,7 @@ import {
 } from "@ai16z/eliza";
 import { ChargeContent, ChargeSchema, isChargeContent } from "../types";
 import { chargeTemplate, getChargeTemplate } from "../templates";
+import { getWalletDetails } from "../utils";
 
 const url = "https://api.commerce.coinbase.com/charges";
 interface ChargeRequest {
@@ -420,7 +421,11 @@ export const chargeProvider: Provider = {
         const charges = await getAllCharges(
             runtime.getSetting("COINBASE_COMMERCE_KEY")
         );
-        return charges.data;
+        const { balances, transactions } = await getWalletDetails(runtime);
+        elizaLogger.log("Charges:", charges);
+        elizaLogger.log("Current Balances:", balances);
+        elizaLogger.log("Last Transactions:", transactions);
+        return { charges: charges.data, balances, transactions };
     },
 };
 

--- a/packages/plugin-coinbase/src/plugins/massPayments.ts
+++ b/packages/plugin-coinbase/src/plugins/massPayments.ts
@@ -34,7 +34,7 @@ const baseDir = path.resolve(__dirname, "../../plugin-coinbase/src/plugins");
 const csvFilePath = path.join(baseDir, "transactions.csv");
 
 export const massPayoutProvider: Provider = {
-    get: async (runtime: IAgentRuntime, message: Memory) => {
+    get: async (runtime: IAgentRuntime, _message: Memory) => {
         try {
             Coinbase.configure({
                 apiKeyName:

--- a/packages/plugin-coinbase/src/plugins/massPayments.ts
+++ b/packages/plugin-coinbase/src/plugins/massPayments.ts
@@ -36,6 +36,14 @@ const csvFilePath = path.join(baseDir, "transactions.csv");
 export const massPayoutProvider: Provider = {
     get: async (runtime: IAgentRuntime, message: Memory) => {
         try {
+            Coinbase.configure({
+                apiKeyName:
+                    runtime.getSetting("COINBASE_API_KEY") ??
+                    process.env.COINBASE_API_KEY,
+                privateKey:
+                    runtime.getSetting("COINBASE_PRIVATE_KEY") ??
+                    process.env.COINBASE_PRIVATE_KEY,
+            });
             elizaLogger.log("Reading CSV file from:", csvFilePath);
 
             // Ensure the CSV file exists
@@ -376,7 +384,7 @@ Check the CSV file for full details.`,
             {
                 user: "{{user1}}",
                 content: {
-                    text: "Distribute 0.0001 ETH on base network to 0xA0ba2ACB5846A54834173fB0DD9444F756810f06 and 0xF14F2c49aa90BaFA223EE074C1C33b59891826bF",
+                    text: "Distribute 0.0001 ETH on base to 0xA0ba2ACB5846A54834173fB0DD9444F756810f06 and 0xF14F2c49aa90BaFA223EE074C1C33b59891826bF",
                 },
             },
             {

--- a/packages/plugin-coinbase/src/plugins/massPayments.ts
+++ b/packages/plugin-coinbase/src/plugins/massPayments.ts
@@ -25,7 +25,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import fs from "fs";
 import { createArrayCsvWriter } from "csv-writer";
-import { initializeWallet } from "../utils";
+import { getWalletDetails, initializeWallet } from "../utils";
 
 // Dynamically resolve the file path to the src/plugins directory
 const __filename = fileURLToPath(import.meta.url);
@@ -34,11 +34,11 @@ const baseDir = path.resolve(__dirname, "../../plugin-coinbase/src/plugins");
 const csvFilePath = path.join(baseDir, "transactions.csv");
 
 export const massPayoutProvider: Provider = {
-    get: async (_runtime: IAgentRuntime, _message: Memory) => {
+    get: async (runtime: IAgentRuntime, message: Memory) => {
         try {
             elizaLogger.log("Reading CSV file from:", csvFilePath);
 
-            // Check if the file exists; if not, create it with headers
+            // Ensure the CSV file exists
             if (!fs.existsSync(csvFilePath)) {
                 elizaLogger.warn("CSV file not found. Creating a new one.");
                 const csvWriter = createArrayCsvWriter({
@@ -62,17 +62,26 @@ export const massPayoutProvider: Provider = {
                 skip_empty_lines: true,
             });
 
+            const { balances, transactions } = await getWalletDetails(runtime);
+
             elizaLogger.log("Parsed CSV records:", records);
-            return records.map((record: any) => ({
-                address: record["Address"] || undefined,
-                amount: parseFloat(record["Amount"]) || undefined,
-                status: record["Status"] || undefined,
-                errorCode: record["Error Code"] || "",
-                transactionUrl: record["Transaction URL"] || "",
-            }));
+            elizaLogger.log("Current Balances:", balances);
+            elizaLogger.log("Last Transactions:", transactions);
+
+            return {
+                currentTransactions: records.map((record: any) => ({
+                    address: record["Address"] || undefined,
+                    amount: parseFloat(record["Amount"]) || undefined,
+                    status: record["Status"] || undefined,
+                    errorCode: record["Error Code"] || "",
+                    transactionUrl: record["Transaction URL"] || "",
+                })),
+                balances,
+                transactionHistory: transactions,
+            };
         } catch (error) {
             elizaLogger.error("Error in massPayoutProvider:", error);
-            return [];
+            return { csvRecords: [], balances: [], transactions: [] };
         }
     },
 };

--- a/packages/plugin-coinbase/src/plugins/trade.ts
+++ b/packages/plugin-coinbase/src/plugins/trade.ts
@@ -31,6 +31,14 @@ const tradeCsvFilePath = path.join(baseDir, "trades.csv");
 export const tradeProvider: Provider = {
     get: async (runtime: IAgentRuntime, _message: Memory) => {
         try {
+            Coinbase.configure({
+                apiKeyName:
+                    runtime.getSetting("COINBASE_API_KEY") ??
+                    process.env.COINBASE_API_KEY,
+                privateKey:
+                    runtime.getSetting("COINBASE_PRIVATE_KEY") ??
+                    process.env.COINBASE_PRIVATE_KEY,
+            });
             elizaLogger.log("Reading CSV file from:", tradeCsvFilePath);
 
             // Check if the file exists; if not, create it with headers
@@ -239,7 +247,7 @@ export const executeTradeAction: Action = {
             {
                 user: "{{user1}}",
                 content: {
-                    text: "Trade 0.00001 ETH for USDC on the base",
+                    text: "Trade 0.00001 ETH for USDC on base",
                 },
             },
             {

--- a/packages/plugin-coinbase/src/utils.ts
+++ b/packages/plugin-coinbase/src/utils.ts
@@ -176,7 +176,9 @@ export async function getWalletDetails(
 
         // Fetch the wallet's recent transactions
         const walletAddress = await wallet.getDefaultAddress();
-        const transactions = (await walletAddress.listTransactions()).data;
+        const transactions = (
+            await walletAddress.listTransactions({ limit: 10 })
+        ).data;
 
         const formattedTransactions = transactions.map((transaction) => {
             const content = transaction.content();

--- a/packages/plugin-coinbase/src/utils.ts
+++ b/packages/plugin-coinbase/src/utils.ts
@@ -1,11 +1,12 @@
-import { Wallet, WalletData } from "@coinbase/coinbase-sdk";
+import { Coinbase, Wallet, WalletData } from "@coinbase/coinbase-sdk";
 import { elizaLogger, IAgentRuntime } from "@ai16z/eliza";
 import fs from "fs";
 import path from "path";
+import { EthereumTransaction } from "@coinbase/coinbase-sdk/dist/client";
 
 export async function initializeWallet(
     runtime: IAgentRuntime,
-    networkId: string
+    networkId: string = Coinbase.networks.EthereumMainnet
 ) {
     let wallet: Wallet;
     const storedSeed =
@@ -122,4 +123,79 @@ export async function updateCharacterSecrets(
         return false;
     }
     return true;
+}
+
+export const getAssetType = (transaction: EthereumTransaction) => {
+    // Check for ETH
+    if (transaction.value && transaction.value !== "0") {
+        return "ETH";
+    }
+
+    // Check for ERC-20 tokens
+    if (transaction.token_transfers && transaction.token_transfers.length > 0) {
+        return transaction.token_transfers
+            .map((transfer) => {
+                return transfer.token_id;
+            })
+            .join(", ");
+    }
+
+    return "N/A";
+};
+
+/**
+ * Fetches and formats wallet balances and recent transactions.
+ *
+ * @param {IAgentRuntime} runtime - The runtime for wallet initialization.
+ * @param {string} networkId - The network ID (optional, defaults to ETH mainnet).
+ * @returns {Promise<{balances: Array<{asset: string, amount: string}>, transactions: Array<any>}>} - An object with formatted balances and transactions.
+ */
+export async function getWalletDetails(
+    runtime: IAgentRuntime,
+    networkId: string = Coinbase.networks.EthereumMainnet
+): Promise<{
+    balances: Array<{ asset: string; amount: string }>;
+    transactions: Array<{
+        timestamp: string;
+        amount: string;
+        asset: string; // Ensure getAssetType is implemented
+        status: string;
+        transactionUrl: string;
+    }>;
+}> {
+    try {
+        // Initialize the wallet, defaulting to the specified network or ETH mainnet
+        const wallet = await initializeWallet(runtime, networkId);
+
+        // Fetch balances
+        const balances = await wallet.listBalances();
+        const formattedBalances = Array.from(balances, (balance) => ({
+            asset: balance[0],
+            amount: balance[1].toString(),
+        }));
+
+        // Fetch the wallet's recent transactions
+        const walletAddress = await wallet.getDefaultAddress();
+        const transactions = (await walletAddress.listTransactions()).data;
+
+        const formattedTransactions = transactions.map((transaction) => {
+            const content = transaction.content();
+            return {
+                timestamp: content.block_timestamp || "N/A",
+                amount: content.value || "N/A",
+                asset: getAssetType(content) || "N/A", // Ensure getAssetType is implemented
+                status: transaction.getStatus(),
+                transactionUrl: transaction.getTransactionLink() || "N/A",
+            };
+        });
+
+        // Return formatted data
+        return {
+            balances: formattedBalances,
+            transactions: formattedTransactions,
+        };
+    } catch (error) {
+        console.error("Error fetching wallet details:", error);
+        throw new Error("Unable to retrieve wallet details.");
+    }
 }


### PR DESCRIPTION
---

# Relates to:

Enhance Providers with Wallet History (Transactions and Balances)



# Risks
Low.
- The new functionality fetches and formats wallet balances and transactions. 
- Possible risks include:
  - Increased response time for providers due to the added API calls.
  - Dependency on the Coinbase SDK for accurate data retrieval.

# Background

## What does this PR do?
This PR enhances the `massPayoutProvider`, `tradeProvider`, and `chargeProvider` to include wallet balances and recent transactions in their responses. Additionally:
1. A reusable utility function `getWalletDetails` is introduced to:
   - Fetch wallet balances.
   - Retrieve recent wallet transactions.
   - Format and return this data.
2. The `getAssetType` helper function is added to determine the asset type (e.g., ETH, USDC) for transactions.

## What kind of change is this?
**Feature (non-breaking change which adds functionality)**  
This PR extends existing providers to include wallet details, making them more informative and versatile.

## Why are we doing this? Any context or related work?
This enhancement allows users to:
- View current wallet balances alongside provider data (e.g., payouts, trades, or charges).
- Understand recent wallet activity, including transaction timestamps, asset types, and statuses.
The goal is to provide a unified source of wallet-related insights within each provider.

# Documentation changes needed?
Yes.  
The functionality of the affected providers now includes wallet details. The documentation should reflect:
1. Input parameters: No changes required.
2. Output: Providers now return wallet balances and recent transactions in addition to their existing data.

# Testing

## Where should a reviewer start?
1. Review the `getWalletDetails` function in `utils.ts` for implementation details.
2. Check the updated `massPayoutProvider`, `tradeProvider`, and `chargeProvider` for integration of wallet details.

## Detailed testing steps
1. Configure the Coinbase SDK with a valid wallet and network (e.g., Ethereum mainnet).
2. Call the following providers:
   - `massPayoutProvider.get()`
   - `tradeProvider.get()`
   - `chargeProvider.get()`
3. Verify:
   - Balances include correct asset types and amounts.
   - Transactions include valid timestamps, asset types, statuses, and URLs.
   - Original provider data (e.g., CSV records, charges, or trades) remains unaffected.
4. Test scenarios with:
   - Wallets containing no balances or transactions.
   - Wallets with multiple assets.
5. Edge cases:
   - Unsupported networks or invalid wallet configurations.
   - Handling of unknown token types in `getAssetType`.

# Screenshots
### Before
**`massPayoutProvider` Output:**
```json
{
  "csvRecords": [
    {
      "address": "0x123...",
      "amount": 0.01,
      "status": "Success",
      "errorCode": "",
      "transactionUrl": "https://etherscan.io/tx/0x..."
    }
  ]
}
```

### After
**`massPayoutProvider` Output:**
```json
{
  "csvRecords": [
    {
      "address": "0x123...",
      "amount": 0.01,
      "status": "Success",
      "errorCode": "",
      "transactionUrl": "https://etherscan.io/tx/0x..."
    }
  ],
  "balances": [
    { "asset": "ETH", "amount": "1.23" },
    { "asset": "USDC", "amount": "500.45" }
  ],
  "transactionHistory": [
    {
      "timestamp": "2024-11-26T14:15:22Z",
      "amount": "100",
      "asset": "USDC",
      "status": "Completed",
      "transactionUrl": "https://etherscan.io/tx/0x..."
    }
  ]
}

```

<img width="1546" alt="Screenshot 2024-11-28 at 2 13 08 PM" src="https://github.com/user-attachments/assets/6a57ce6c-a08c-4a44-8aae-51e93b1c516d">

# Deploy Notes
No special deployment steps are required. Ensure:
- The Coinbase SDK is configured correctly with API keys and secrets.
- The environment supports the required network IDs.

# Database changes
None.

# Deployment instructions
Standard deployment.
