### PR TITLE
fix: add missing commands to quickstart

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -44,6 +44,12 @@ Before getting started with Eliza, ensure you have:
    pnpm install
    ```
 
+   Build the local libraries
+
+   ```bash
+   pnpm build
+   ```
+
 2. **Configure Environment**
 
    Copy example environment file
@@ -259,7 +265,7 @@ pnpm start --characters="characters/trump.character.json,characters/tate.charact
    If that doesn't work, try clearing your node_modules in the root folder
 
    ```bash
-   rm -fr node_modules; rm pnpm-lock.yaml
+   rm -fr node_modules; pnpm store prune
    ```
 
    Then reinstall the requirements


### PR DESCRIPTION
# Relates to:

https://github.com/ai16z/eliza/issues/337

# Risks

Low

# Background

## What does this PR do?
**1. Add a "Build Local Libraries" Step:**
Included the `pnpm build` step in the quickstart guide to address an issue where running pnpm start would fail due to missing imported libraries. This ensures the project is properly built before starting.

**2. Improve better-sqlite3 Troubleshooting Instructions:**

Added `pnpm store prune` as a troubleshooting step for resolving issues with better-sqlite3.

Deleting the pnpm-lock.yaml file is unnecessary since the library versions remain consistent. The root cause is related to the `pnpm` cache retaining an incompatible version of the package, which occurs when using a different Node.js version during the initial installation.

## What kind of change is this?
Improve docs

## Why are we doing this? Any context or related work?
Got stuck while following the quickstart, saw other people had the same problem.

## Discord username
aguspunk
