### PR TITLE
feat: evm pubkey derivation

### DIFF
--- a/scripts/derive-keys.js
+++ b/scripts/derive-keys.js
@@ -1,0 +1,19 @@
+const { ethers } = require('ethers');
+require('dotenv').config();
+
+// Get and validate the private key
+const privateKey = process.env.EVM_PRIVATE_KEY;
+if (!privateKey) {
+    throw new Error('EVM_PRIVATE_KEY is not set in environment variables');
+}
+
+// Ensure the private key has the correct format
+const formattedPrivateKey = privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`;
+
+// Create a wallet instance
+const wallet = new ethers.Wallet(formattedPrivateKey);
+
+console.log('\nWallet Information:');
+console.log('------------------');
+console.log('Public Key:', wallet.signingKey.publicKey);
+console.log('Wallet Address:', wallet.address);


### PR DESCRIPTION
A quick easy way to derive your EVM pubkey from the EVM_PRIVATE_KEY set in your .env file without needing to access the key generation system in the new TEE feature.

Relates to:
This is simply a super easy convenience PR to help devs move their agents into EVM testing much more quickly.

Risks
There's basically no risk to the PR. It's a super simple helper script that operates outside of the existing codebase and framework.

Background
As I went to setup the EVM integration for the Gods - I realized there wasn't an easy way to derive EVM public keys from the EVM private key. This also paves the way to simplifying the .env file requirements and thus simplifying the setup process.

Documentation changes needed?
It would be great to mention this in any "get started" content relating to EVM agents.

Set your private key in the .env EVM_PRIVATE_KEY and run node scripts/derive-keys.js
Set your public key EVM_PUBLIC_KEY from the public key output in your console

Testing
Can test by simply importing an EVM_PRIVATE_KEY into the .env file and bashing node scripts/derive-keys.js