### PR TITLE
Add getAccountsByIds postgres example

### DIFF
--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -18,22 +18,9 @@ export async function getActorDetails({
 }) {
     const participantIds =
         await runtime.databaseAdapter.getParticipantsForRoom(roomId);
-    const actors = await Promise.all(
-        participantIds.map(async (userId) => {
-            const account =
-                await runtime.databaseAdapter.getAccountById(userId);
-            if (account) {
-                return {
-                    id: account.id,
-                    name: account.name,
-                    username: account.username,
-                    details: account.details,
-                };
-            }
-            return null;
-        })
+    const actors = await runtime.databaseAdapter.getAccountsByIds(
+        participantIds
     );
-
     return actors.filter((actor): actor is Actor => actor !== null);
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -731,6 +731,9 @@ export interface IDatabaseAdapter {
     /** Get account by ID */
     getAccountById(userId: UUID): Promise<Account | null>;
 
+    /** Get accounts by IDs */
+    getAccountsByIds(userIds: UUID[]): Promise<Account[]>;
+
     /** Create new account */
     createAccount(account: Account): Promise<boolean>;
 


### PR DESCRIPTION
# Relates to:

https://discord.com/channels/1253563208833433701/1253563209462448241/1312119096514580550

# Risks

Large: The `getAccountsByIds` function was added to IDatabaseAdapter, but only implemented for the postgres adapter.

# Background

## What does this PR do?

Adds `getAccountsByIds` to IDatabaseAdapter and implements in postgres adapter so that `getActorDetails` can fetch accounts in batch. Otherwise, when participantIds is large, the database gets hammered.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)

## Why are we doing this? Any context or related work?

See above

# Testing

This PR has not been tested. Dependencies haven't even been installed locally.

## Where should a reviewer start?

See if the app still runs 😂 

## Discord username

CalvinLeGassick, tito