### PR TITLE
refactor: ClientBase to use a map for managing multiple Twitter clients by account identifier

### DIFF
--- a/packages/client-twitter/src/base.ts
+++ b/packages/client-twitter/src/base.ts
@@ -82,7 +82,7 @@ class RequestQueue {
 }
 
 export class ClientBase extends EventEmitter {
-    static _twitterClient: Scraper;
+    static _twitterClients: { [accountIdentifier: string]: Scraper } = {};
     twitterClient: Scraper;
     runtime: IAgentRuntime;
     directions: string;
@@ -137,11 +137,15 @@ export class ClientBase extends EventEmitter {
     constructor(runtime: IAgentRuntime) {
         super();
         this.runtime = runtime;
-        if (ClientBase._twitterClient) {
-            this.twitterClient = ClientBase._twitterClient;
+        if (!ClientBase._twitterClients) {
+            ClientBase._twitterClients = {};
+        }
+        const username = this.runtime.getSetting("TWITTER_USERNAME");
+        if (ClientBase._twitterClients[username]) {
+            this.twitterClient = ClientBase._twitterClients[username];
         } else {
             this.twitterClient = new Scraper();
-            ClientBase._twitterClient = this.twitterClient;
+            ClientBase._twitterClients[username] = this.twitterClient;
         }
 
         this.directions =
@@ -420,7 +424,7 @@ export class ClientBase extends EventEmitter {
                         content: content,
                         agentId: this.runtime.agentId,
                         roomId,
-                        embedding: getEmbeddingZeroVector(this.runtime),
+                        embedding: getEmbeddingZeroVector(),
                         createdAt: tweet.timestamp * 1000,
                     });
 
@@ -533,7 +537,7 @@ export class ClientBase extends EventEmitter {
                 content: content,
                 agentId: this.runtime.agentId,
                 roomId,
-                embedding: getEmbeddingZeroVector(this.runtime),
+                embedding: getEmbeddingZeroVector(),
                 createdAt: tweet.timestamp * 1000,
             });
 
@@ -575,7 +579,7 @@ export class ClientBase extends EventEmitter {
             } else {
                 await this.runtime.messageManager.createMemory({
                     ...message,
-                    embedding: getEmbeddingZeroVector(this.runtime),
+                    embedding: getEmbeddingZeroVector(),
                 });
             }
 

--- a/packages/client-twitter/src/base.ts
+++ b/packages/client-twitter/src/base.ts
@@ -137,9 +137,6 @@ export class ClientBase extends EventEmitter {
     constructor(runtime: IAgentRuntime) {
         super();
         this.runtime = runtime;
-        if (!ClientBase._twitterClients) {
-            ClientBase._twitterClients = {};
-        }
         const username = this.runtime.getSetting("TWITTER_USERNAME");
         if (ClientBase._twitterClients[username]) {
             this.twitterClient = ClientBase._twitterClients[username];

--- a/packages/client-twitter/src/base.ts
+++ b/packages/client-twitter/src/base.ts
@@ -424,7 +424,7 @@ export class ClientBase extends EventEmitter {
                         content: content,
                         agentId: this.runtime.agentId,
                         roomId,
-                        embedding: getEmbeddingZeroVector(),
+                        embedding: getEmbeddingZeroVector(this.runtime),
                         createdAt: tweet.timestamp * 1000,
                     });
 
@@ -537,7 +537,7 @@ export class ClientBase extends EventEmitter {
                 content: content,
                 agentId: this.runtime.agentId,
                 roomId,
-                embedding: getEmbeddingZeroVector(),
+                embedding: getEmbeddingZeroVector(this.runtime),
                 createdAt: tweet.timestamp * 1000,
             });
 
@@ -579,7 +579,7 @@ export class ClientBase extends EventEmitter {
             } else {
                 await this.runtime.messageManager.createMemory({
                     ...message,
-                    embedding: getEmbeddingZeroVector(),
+                    embedding: getEmbeddingZeroVector(this.runtime),
                 });
             }
 


### PR DESCRIPTION
related: https://github.com/ai16z/eliza/issues/656

I think the issue arises because the Scraper instance is shared across different accounts, causing auth and authTrends to be overwritten when a new account is used: 
https://github.com/ai16z/agent-twitter-client/blob/e1d86267681c44529ba3dc4b5125e1dc965ed0fc/src/scraper.ts#L665
