### PR TITLE
fix: twitter recent interactions

### DIFF
--- a/packages/client-twitter/src/interactions.ts
+++ b/packages/client-twitter/src/interactions.ts
@@ -41,12 +41,11 @@ Recent interactions between {{agentName}} and other users:
 
 {{recentPosts}}
 
-
 # Task: Generate a post/reply in the voice, style and perspective of {{agentName}} (@{{twitterUserName}}) while using the thread of tweets as additional context:
 Current Post:
 {{currentPost}}
-Thread of Tweets You Are Replying To:
 
+Thread of Tweets You Are Replying To:
 {{formattedConversation}}
 
 {{actions}}

--- a/packages/client-twitter/src/utils.ts
+++ b/packages/client-twitter/src/utils.ts
@@ -192,8 +192,8 @@ export async function sendTweet(
                 id: tweetResult.rest_id,
                 text: tweetResult.legacy.full_text,
                 conversationId: tweetResult.legacy.conversation_id_str,
-                //createdAt:
-                timestamp: tweetResult.timestamp * 1000,
+                timestamp:
+                    new Date(tweetResult.legacy.created_at).getTime() / 1000,
                 userId: tweetResult.legacy.user_id_str,
                 inReplyToStatusId: tweetResult.legacy.in_reply_to_status_id_str,
                 permanentUrl: `https://twitter.com/${twitterUsername}/status/${tweetResult.rest_id}`,

--- a/packages/plugin-bootstrap/src/providers/facts.ts
+++ b/packages/plugin-bootstrap/src/providers/facts.ts
@@ -46,6 +46,10 @@ const factsProvider: Provider = {
                 index === self.findIndex((t) => t.id === fact.id)
         );
 
+        if (allFacts.length === 0) {
+            return "";
+        }
+
         const formattedFacts = formatFacts(allFacts);
 
         return "Key facts that {{agentName}} knows:\n{{formattedFacts}}"


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

Twitter memories for agent generated tweets weren't being saved properly due to null created_at values

# Risks

Low

# Background

## What does this PR do?

Uses the actual timestamp value for a sent tweet

## What kind of change is this?

Bug fix

<!-- This "Why" section is most relevant if there is no linked issue explaining why. If there is a related issue it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested, and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None, automated tests are fine.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deploy, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste commandline output. -->
<!--
## Database changes
-->

<!--  If there is something more than the automated steps, please specifiy deploy instructions. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for contribute role and join us in #development-feed -->
<!--
## Discord username

-->
