### PR TITLE
fix: packagejson updated to latest agent-client 0.0.16

### DIFF
--- a/packages/client-twitter/package.json
+++ b/packages/client-twitter/package.json
@@ -6,7 +6,7 @@
     "types": "dist/index.d.ts",
     "dependencies": {
         "@ai16z/eliza": "workspace:*",
-        "agent-twitter-client": "0.0.14",
+        "agent-twitter-client": "0.0.16",
         "glob": "11.0.0",
         "zod": "3.23.8"
     },


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:
Package wasn't uptodate
<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section is to be filled out before final review and merge. -->

# Risks

low

# Background
Package wasn't uptodate
## What does this PR do?
Package updated to latest agentclient repo 0.0.16 where sendTweet also support media sending.
