### PR TITLE
fix: recentPosts always empty

### DIFF
--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -83,9 +83,9 @@ export class TwitterPostClient {
 
             const lastPostTimestamp = lastPost?.timestamp ?? 0;
             const minMinutes =
-                parseInt(this.runtime.getSetting("POST_INTERVAL_MIN")) || 1;
+                parseInt(this.runtime.getSetting("POST_INTERVAL_MIN")) || 90;
             const maxMinutes =
-                parseInt(this.runtime.getSetting("POST_INTERVAL_MAX")) || 1;
+                parseInt(this.runtime.getSetting("POST_INTERVAL_MAX")) || 180;
             const randomMinutes =
                 Math.floor(Math.random() * (maxMinutes - minMinutes + 1)) +
                 minMinutes;
@@ -180,7 +180,7 @@ export class TwitterPostClient {
                     twitterPostTemplate,
             });
 
-            console.log("generate post prompt:\n" + context);
+            elizaLogger.debug("generate post prompt:\n" + context);
 
             const newTweetContent = await generateText({
                 runtime: this.runtime,


### PR DESCRIPTION
related: https://github.com/ai16z/eliza/issues/679

PR Description:

**Unified Room ID Handling:** 
Ensures consistency by using the same room ID when creating and retrieving memories addressing an issue where {{recentPosts}} in post.ts/twitter was always empty.

**Added Missing timestamp Property for Tweets:** 
Introduced the missing timestamp property to tweets, enabling accurate retrieval of the creation date for recent posts.