### PR TITLE
refactor: update `package.json` and `turbo.json` for improved build and development scripts

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ai16z/agent",
     "version": "0.1.4-alpha.3",
-    "main": "dist/index.ts",
+    "main": "dist/index.js",
     "type": "module",
     "scripts": {
         "start": "node dist/index.js",

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ai16z/agent",
     "version": "0.1.4-alpha.3",
-    "main": "dist/index.js",
+    "main": "dist/index.ts",
     "type": "module",
     "scripts": {
         "start": "node dist/index.js",
@@ -15,7 +15,7 @@
             "../core/dist"
         ],
         "ext": "js,json",
-        "exec": "node --enable-source-maps dist/index.js"
+        "exec": "node --enable-source-maps dist/index.ts"
     },
     "dependencies": {
         "@ai16z/adapter-postgres": "workspace:*",

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,20 +1,21 @@
 {
     "name": "@ai16z/agent",
     "version": "0.1.4-alpha.3",
-    "main": "src/index.ts",
+    "main": "dist/index.js",
     "type": "module",
     "scripts": {
-        "start": "node --loader ts-node/esm src/index.ts",
-        "dev": "node --loader ts-node/esm src/index.ts",
+        "start": "node dist/index.js",
+        "dev": "tsup --format esm --dts --watch src/index.ts",
+        "build": "tsup --format esm --dts src/index.ts",
         "check-types": "tsc --noEmit"
     },
     "nodemonConfig": {
         "watch": [
-            "src",
+            "dist",
             "../core/dist"
         ],
-        "ext": "ts,json",
-        "exec": "node --enable-source-maps --loader ts-node/esm src/index.ts"
+        "ext": "js,json",
+        "exec": "node --enable-source-maps dist/index.js"
     },
     "dependencies": {
         "@ai16z/adapter-postgres": "workspace:*",

--- a/agent/package.json
+++ b/agent/package.json
@@ -15,7 +15,7 @@
             "../core/dist"
         ],
         "ext": "js,json",
-        "exec": "node --enable-source-maps dist/index.ts"
+        "exec": "node --enable-source-maps dist/index.js"
     },
     "dependencies": {
         "@ai16z/adapter-postgres": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "start": "pnpm --filter \"@ai16z/agent\" start --isRoot",
         "start:client": "pnpm --dir client start --isRoot",
         "start:debug": "cross-env NODE_ENV=development VERBOSE=true DEBUG=eliza:* pnpm --filter \"@ai16z/agent\" start --isRoot",
-        "dev": "turbo check-types dev --concurrency 25",
+        "dev": "turbo run dev --parallel --no-cache",
         "lint": "bash ./scripts/lint.sh",
         "prettier-check": "npx prettier --check .",
         "prettier": "npx prettier --write .",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
         "build": "tsup --format esm --dts",
         "lint": "eslint . --fix",
         "watch": "tsc --watch",
-        "dev": "tsup --format esm --dts --watch",
+        "dev": "tsup --format esm --dts --watch src/index.ts",
         "build:docs": "cd docs && pnpm run build",
         "test": "vitest run",
         "test:coverage": "vitest run --coverage",

--- a/turbo.json
+++ b/turbo.json
@@ -1,26 +1,15 @@
 {
     "$schema": "https://turbo.build/schema.json",
     "tasks": {
-        "check-types": {
-            "dependsOn": ["build"]
-        },
-        "@ai16z/agent#check-types": {
-            "dependsOn": ["@ai16z/plugin-solana#build"]
+        "dev": {
+            "persistent": true,
+            "cache": false,
+            "dependsOn": ["^build"],
+            "outputs": ["dist/**"]
         },
         "build": {
             "outputs": ["dist/**"],
-            "dependsOn": ["^@ai16z/eliza#build"]
-        },
-        "@ai16z/plugin-solana#build": {
-            "outputs": ["dist/**"],
-            "dependsOn": ["@ai16z/plugin-trustdb#build"]
-        },
-        "eliza-docs#build": {
-            "outputs": ["build/**"]
-        },
-        "dev": {
-            "persistent": true,
-            "cache": false
+            "dependsOn": ["^build"]
         }
     }
 }


### PR DESCRIPTION

# Relates to:

[pnpm run dev does not work out of the box #780](https://github.com/ai16z/eliza/issues/780)

<!-- This risks section is to be filled out before final review and merge. -->

# Risks

Medium. While the build system improvements work as expected, the type error in the postgres adapter could affect database operations that rely on embedding configurations. (see next)

# Background

## What does this PR do?

- Changed the 'dev' script in package.json to use 'turbo run dev --parallel --no-cache' for better performance
- Updated turbo.json to streamline task dependencies and outputs for the 'dev' and 'build' tasks
- Modified agent/package.json to point the main entry to 'dist/index.js' and adjusted scripts for building and starting the application
- Enhanced core/package.json 'dev' script to specify the source file for watching during development

However, during testing I discovered a type error that needs to be addressed in some future PR:

```Module '"@ai16z/eliza"' has no exported member 'getEmbeddingConfig'.```

This error appears in `packages/adapter-postgres/src/index.ts` when trying to import `getEmbeddingConfig` from the core package.


## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

See [pnpm run dev does not work out of the box #780](https://github.com/ai16z/eliza/issues/780)

# Documentation changes needed?

No

# Testing

## Where should a reviewer start?

1. Run `pnpm i`
2. Run `pnpm run dev`
3. Verify that all packages start building in watch mode
4. Note the type error in the postgres adapter that needs to be fixed in a follow-up PR


## Detailed testing steps

1. Check that turbo correctly runs builds in parallel
2. Verify that file changes trigger rebuilds appropriately
3. Confirm that the build dependencies are working (core package builds before dependent packages)
4. Note the type error in postgres adapter needs fixing:
   - File: `packages/adapter-postgres/src/index.ts`
   - Error: `Module '"@ai16z/eliza"' has no exported member 'getEmbeddingConfig'`


# Deploy Notes

The type error in the postgres adapter should be fixed before deploying to prod/new release. The build system changes themselves are ready for deployment.