### PR TITLE
fix: Docker default non-interactive mode for Cloud instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/characters ./characters
 
 # Set the command to run the application
-CMD ["pnpm", "start", "non-interactive"]
+CMD ["pnpm", "start", "--non-interactive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/characters ./characters
 
 # Set the command to run the application
-CMD ["pnpm", "start"]
+CMD ["pnpm", "start", "non-interactive"]

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -485,7 +485,9 @@ const startAgents = async () => {
     }
 
     elizaLogger.log("Chat started. Type 'exit' to quit.");
-    chat();
+    if (!args["non-interactive"]) {
+        chat();
+    }
 };
 
 startAgents().catch((error) => {


### PR DESCRIPTION
# Relates to:

<!-- LINK TO ISSUE OR TICKET -->
No linked issue.

# Risks

<!--
Low, medium, large. List what kind of risks, and what could be effected.
-->
**Risk Level**: Low  
Adding a new flag `non-interactive` that defaults to skipping `chat()` should not affect existing functionality unless explicitly enabled. The main risk is around unintended bypass of user input under edge cases.

# Background

## What does this PR do?
This PR adds a `non-interactive` flag to prevent running the `chat()` function and avoid waiting for user input. This is particularly useful for environments such as Cloud platforms where interactive sessions are not feasible and can cause the application to hang.

Additionally, the `non-interactive` flag is added to the `CMD` in the Dockerfile as the default.

## What kind of change is this?
Features (non-breaking change which adds functionality)

<!-- This "Why" section is most relevant if there is no linked issue explaining why. If there is a related issue it might make sense to skip this why section. -->
## Why are we doing this? Any context or related work?
Running the application in a non-interactive environment such as Cloud platforms caused the process to hang due to waiting for terminal input. Adding this flag makes the application more robust for deployment in such scenarios.

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If a docs change is needed: I have updated the documentation accordingly.
-->
My changes **do not** require a change to the project documentation.

# Testing

## Where should a reviewer start?
- Review the changes in the `Dockerfile` for the updated `CMD` with the `non-interactive` flag.
- Review the changes in `/agent/src/index.ts` where the `non-interactive` flag is implemented and its logic for skipping `chat()`.

## Detailed testing steps
1. Run the application locally without the `non-interactive` flag and verify that `chat()` runs as expected.
2. Run the application locally with the `non-interactive` flag and confirm it bypasses `chat()` and does not wait for user input.
3. Build and run the updated Docker image to ensure the `non-interactive` flag is applied by default and prevents hanging in Cloud environments.

# Deploy Notes

No special deployment steps are required. Ensure the updated Docker image is pushed to the appropriate registry.

## Database changes

None.

## Deployment instructions

Build and deploy the updated Docker image as usual.

---

Let me know if anything else needs tweaking! 😊
<!--
## Discord username
@rarepepi
-->
