### PR TITLE
refactor: Improve actions samples random selection

### DIFF
--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -14,7 +14,7 @@ export const composeActionExamples = (actionsData: Action[], count: number) => {
     ]);
 
     const actionExamples: ActionExample[][] = [];
-    const length = data.length;
+    let length = data.length;
     for (let i = 0; i < count && length; i++) {
         const actionId = i % length;
         const examples = data[actionId];

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -9,13 +9,27 @@ import { Action, ActionExample } from "./types.ts";
  * @returns A string containing formatted examples of conversations.
  */
 export const composeActionExamples = (actionsData: Action[], count: number) => {
-    const actionExamples: ActionExample[][] = actionsData
-        .sort(() => 0.5 - Math.random())
-        .map((action: Action) =>
-            action.examples.sort(() => 0.5 - Math.random()).slice(0, 5)
-        )
-        .flat()
-        .slice(0, count);
+    const data: ActionExample[][][] = actionsData.map((action: Action) => [
+        ...action.examples,
+    ]);
+
+    const actionExamples: ActionExample[][] = [];
+    const length = data.length;
+    for (let i = 0; i < count && length; i++) {
+        const actionId = i % length;
+        const examples = data[actionId];
+        if (examples.length) {
+            const rand = ~~(Math.random() * examples.length);
+            actionExamples[i] = examples.splice(rand, 1)[0];
+        } else {
+            i--;
+        }
+
+        if (examples.length == 0) {
+            data.splice(actionId, 1);
+            length--;
+        }
+    }
 
     const formattedExamples = actionExamples.map((example) => {
         const exampleNames = Array.from({ length: 5 }, () =>


### PR DESCRIPTION
    Improve the action samples random selection by ensuring a bigger variety of actions are represented in the selection (as long as there is enough place, at least one example per action should be added)

<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

https://github.com/ai16z/eliza/issues/798

# Risks

low, but it makes LLM sometimes not understand that they can trigger an action because they don't have any example corresponding

# Background

## What does this PR do?

This PR changes the algorithm that selects the actions examples that are sent to the model

## What kind of change is this?

Improvements

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

not really testable except if you do console logs but the difference is there.