### PR TITLE
fix: Include scripts/postinstall.js in the final NPM package

### DIFF
--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -4,6 +4,13 @@
     "main": "dist/index.js",
     "type": "module",
     "types": "dist/index.d.ts",
+    "files": [
+        "dist",
+        "scripts",
+        "package.json",
+        "LICENSE",
+        "tsup.config.ts"
+    ],
     "dependencies": {
         "@ai16z/eliza": "workspace:*",
         "@cliqz/adblocker-playwright": "1.34.0",


### PR DESCRIPTION
# Relates to:
No specific ticket linked - package configuration improvement

# Risks
Low - Adding explicit files list to package.json for more controlled npm package contents

# Background
## The problem
```bash
# pnpm install
.../node_modules/@ai16z/plugin-node postinstall$ node scripts/postinstall.js
│ node:internal/modules/cjs/loader:1246
│   throw err;
│   ^
│ Error: Cannot find module '/Users/martincik/Projects/ai/access-ai-poc/echo2/node_modules/.pnpm/@ai16z+plugin-node@0.1.5-alpha.3_@google-cloud+vertexai@1.9.0_@langchain+cor…
│     at Function._resolveFilename (node:internal/modules/cjs/loader:1243:15)
│     at Function._load (node:internal/modules/cjs/loader:1068:27)
│     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
│     at wrapModuleLoad (node:internal/modules/cjs/loader:219:24)
│     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5)
│     at node:internal/main/run_main_module:36:49 {
│   code: 'MODULE_NOT_FOUND',
│   requireStack: []
│ }
│ Node.js v23.2.0
```

## Issue
The new package is triggering `postintall` but the scripts/postinstall.js is missing.

## What does this PR do?
Adds "files" field to package.json to explicitly include scripts/postinstall.js and other essential files in the published npm package.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
1. Review packages/plugin-node/package.json
2. Test npm package installation

## Detailed testing steps
1. Build the package locally
2. Verify package contents include:
   - dist/
   - scripts/
   - package.json
   - LICENSE
   - tsup.config.ts
3. Test package installation