### PR TITLE
fix: re-enable coverage report upload to Codecov in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
             - name: Build packages
               run: pnpm run build
 
-            # - name: Upload coverage reports to Codecov
-            #   uses: codecov/codecov-action@v5
-            #   with:
-            #       token: ${{ secrets.CODECOV_TOKEN }}
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v5
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Relates to:
Continuous Integration workflow improvements

# Risks
Low - Changes to CI workflow configuration only. Main risk would be potential CI pipeline failures if any configuration is incorrect.

# Background

## What does this PR do?
Updates the GitHub Actions CI workflow configuration with the following changes:
- Adds code coverage reporting to Codecov

## What kind of change is this?
Improvements (misc. changes to existing features)
- Enhances the existing CI pipeline with better package management and test coverage reporting

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
1. Review the .github/workflows/ci.yaml file
2. Check the workflow runs on both push to main and pull requests
3. Verify all job steps are properly configured

## Detailed testing steps
1. Create a test PR to verify the workflow triggers correctly
2. Ensure all steps complete successfully:
   - PNPM installation
   - Dependencies installation
   - Prettier checks
   - Linting
   - Test environment setup
   - Test execution
   - Package building
   - Code coverage reporting
3. Verify Codecov integration is working by checking coverage reports

The automated CI workflow will validate all changes.

# Deploy Notes
No special deployment needed - changes only affect CI pipeline configuration.
