### PR TITLE
chore: deprecate text based way of generating JSON

### DIFF
--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -672,7 +672,7 @@ export async function generateTextArray({
     }
 }
 
-export async function generateObject({
+export async function generateObjectDEPRECATED({
     runtime,
     context,
     modelClass,
@@ -682,7 +682,7 @@ export async function generateObject({
     modelClass: string;
 }): Promise<any> {
     if (!context) {
-        elizaLogger.error("generateObject context is empty");
+        elizaLogger.error("generateObjectDEPRECATED context is empty");
         return null;
     }
     let retryDelay = 1000;
@@ -1111,7 +1111,7 @@ export const generateObjectV2 = async ({
     mode = "json",
 }: GenerationOptions): Promise<GenerateObjectResult<unknown>> => {
     if (!context) {
-        const errorMessage = "generateObject context is empty";
+        const errorMessage = "generateObjectV2 context is empty";
         console.error(errorMessage);
         throw new Error(errorMessage);
     }
@@ -1204,7 +1204,7 @@ export async function handleProvider(
         case ModelProviderName.GROQ:
             return await handleGroq(options);
         case ModelProviderName.LLAMALOCAL:
-            return await generateObject({
+            return await generateObjectDEPRECATED({
                 runtime,
                 context,
                 modelClass,

--- a/packages/plugin-aptos/src/actions/transfer.ts
+++ b/packages/plugin-aptos/src/actions/transfer.ts
@@ -10,7 +10,7 @@ import {
     type Action,
 } from "@ai16z/eliza";
 import { composeContext } from "@ai16z/eliza";
-import { generateObject } from "@ai16z/eliza";
+import { generateObjectDEPRECATED } from "@ai16z/eliza";
 import {
     Account,
     Aptos,
@@ -111,7 +111,7 @@ export default {
         });
 
         // Generate transfer content
-        const content = await generateObject({
+        const content = await generateObjectDEPRECATED({
             runtime,
             context: transferContext,
             modelClass: ModelClass.SMALL,

--- a/packages/plugin-flow/src/actions/transfer.ts
+++ b/packages/plugin-flow/src/actions/transfer.ts
@@ -2,7 +2,7 @@ import {
     composeContext,
     Content,
     elizaLogger,
-    generateObject,
+    generateObjectDEPRECATED,
     ModelClass,
     type Action,
     type ActionExample,
@@ -87,7 +87,7 @@ export class TransferAction {
         });
 
         // Generate transfer content
-        const content = await generateObject({
+        const content = await generateObjectDEPRECATED({
             runtime,
             context: transferContext,
             modelClass: ModelClass.SMALL,

--- a/packages/plugin-icp/src/actions/createToken.ts
+++ b/packages/plugin-icp/src/actions/createToken.ts
@@ -2,7 +2,7 @@ import {
     composeContext,
     generateImage,
     generateText,
-    generateObject,
+    generateObjectDEPRECATED,
 } from "@ai16z/eliza";
 import {
     ActionExample,
@@ -148,7 +148,7 @@ export const executeCreateToken: Action = {
             template: createTokenTemplate,
         });
 
-        const response = await generateObject({
+        const response = await generateObjectDEPRECATED({
             runtime,
             context: createTokenContext,
             modelClass: ModelClass.LARGE,

--- a/packages/plugin-solana/src/actions/pumpfun.ts
+++ b/packages/plugin-solana/src/actions/pumpfun.ts
@@ -15,7 +15,7 @@ import {
     Memory,
     ModelClass,
     State,
-    generateObject,
+    generateObjectDEPRECATED,
     composeContext,
     type Action,
 } from "@ai16z/eliza";
@@ -262,8 +262,8 @@ Example response:
 Given the recent messages, extract or generate (come up with if not included) the following information about the requested token creation:
 - Token name
 - Token symbol
-- Token description 
-- Token image description 
+- Token description
+- Token image description
 - Amount of SOL to buy
 
 Respond with a JSON markdown block containing only the extracted values.`;
@@ -302,7 +302,7 @@ export default {
             template: pumpfunTemplate,
         });
 
-        const content = await generateObject({
+        const content = await generateObjectDEPRECATED({
             runtime,
             context: pumpContext,
             modelClass: ModelClass.LARGE,
@@ -325,7 +325,7 @@ export default {
                         height: 512,
                         count: 1
                     }, runtime);
-        
+
                     if (imageResult.success && imageResult.data && imageResult.data.length > 0) {
                         // Remove the "data:image/png;base64," prefix if present
                         tokenMetadata.file = imageResult.data[0].replace(/^data:image\/[a-z]+;base64,/, '');

--- a/packages/plugin-solana/src/actions/swap.ts
+++ b/packages/plugin-solana/src/actions/swap.ts
@@ -17,7 +17,7 @@ import {
     State,
     type Action,
     composeContext,
-    generateObject,
+    generateObjectDEPRECATED,
     settings,
 } from "@ai16z/eliza";
 import { TokenProvider } from "../providers/token.ts";
@@ -110,7 +110,7 @@ Example response:
 \`\`\`json
 {
     "inputTokenSymbol": "SOL",
-    "outputTokenSymbol": "USDC", 
+    "outputTokenSymbol": "USDC",
     "inputTokenCA": "So11111111111111111111111111111111111111112",
     "outputTokenCA": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
     "amount": 1.5
@@ -125,7 +125,7 @@ Given the recent messages and wallet information below:
 
 Extract the following information about the requested token swap:
 - Input token symbol (the token being sold)
-- Output token symbol (the token being bought) 
+- Output token symbol (the token being bought)
 - Input token contract address if provided
 - Output token contract address if provided
 - Amount to swap
@@ -134,7 +134,7 @@ Respond with a JSON markdown block containing only the extracted values. Use nul
 \`\`\`json
 {
     "inputTokenSymbol": string | null,
-    "outputTokenSymbol": string | null, 
+    "outputTokenSymbol": string | null,
     "inputTokenCA": string | null,
     "outputTokenCA": string | null,
     "amount": number | string | null
@@ -209,7 +209,7 @@ export const executeSwap: Action = {
             template: swapTemplate,
         });
 
-        const response = await generateObject({
+        const response = await generateObjectDEPRECATED({
             runtime,
             context: swapContext,
             modelClass: ModelClass.LARGE,

--- a/packages/plugin-solana/src/actions/transfer.ts
+++ b/packages/plugin-solana/src/actions/transfer.ts
@@ -24,7 +24,7 @@ import {
     type Action,
 } from "@ai16z/eliza";
 import { composeContext } from "@ai16z/eliza";
-import { generateObject } from "@ai16z/eliza";
+import { generateObjectDEPRECATED } from "@ai16z/eliza";
 
 export interface TransferContent extends Content {
     tokenAddress: string;
@@ -119,7 +119,7 @@ export default {
         });
 
         // Generate transfer content
-        const content = await generateObject({
+        const content = await generateObjectDEPRECATED({
             runtime,
             context: transferContext,
             modelClass: ModelClass.LARGE,

--- a/packages/plugin-starknet/src/actions/subdomain.ts
+++ b/packages/plugin-starknet/src/actions/subdomain.ts
@@ -9,7 +9,7 @@ import {
     State,
     type Action,
     composeContext,
-    generateObject,
+    generateObjectDEPRECATED,
     Content,
     elizaLogger,
 } from "@ai16z/eliza";
@@ -107,7 +107,7 @@ export default {
         });
 
         // Generate transfer content
-        const content = await generateObject({
+        const content = await generateObjectDEPRECATED({
             runtime,
             context: transferContext,
             modelClass: ModelClass.MEDIUM,

--- a/packages/plugin-starknet/src/actions/swap.ts
+++ b/packages/plugin-starknet/src/actions/swap.ts
@@ -3,7 +3,7 @@ import {
     ActionExample,
     composeContext,
     elizaLogger,
-    generateObject,
+    generateObjectDEPRECATED,
     HandlerCallback,
     IAgentRuntime,
     Memory,
@@ -105,7 +105,7 @@ export const executeSwap: Action = {
             template: swapTemplate,
         });
 
-        const response = await generateObject({
+        const response = await generateObjectDEPRECATED({
             runtime,
             context: swapContext,
             modelClass: ModelClass.MEDIUM,

--- a/packages/plugin-starknet/src/actions/transfer.ts
+++ b/packages/plugin-starknet/src/actions/transfer.ts
@@ -7,7 +7,7 @@ import {
     composeContext,
     Content,
     elizaLogger,
-    generateObject,
+    generateObjectDEPRECATED,
     HandlerCallback,
     IAgentRuntime,
     Memory,
@@ -136,7 +136,7 @@ export default {
         });
 
         // Generate transfer content
-        const content = await generateObject({
+        const content = await generateObjectDEPRECATED({
             runtime,
             context: transferContext,
             modelClass: ModelClass.MEDIUM,

--- a/packages/plugin-starknet/src/actions/unruggable.ts
+++ b/packages/plugin-starknet/src/actions/unruggable.ts
@@ -3,7 +3,7 @@ import {
     ActionExample,
     composeContext,
     elizaLogger,
-    generateObject,
+    generateObjectDEPRECATED,
     HandlerCallback,
     IAgentRuntime,
     Memory,
@@ -102,7 +102,7 @@ export const deployToken: Action = {
             template: deployTemplate,
         });
 
-        const response = await generateObject({
+        const response = await generateObjectDEPRECATED({
             runtime,
             context: deployContext,
             modelClass: ModelClass.MEDIUM,


### PR DESCRIPTION
# Relates to:  

N/A prevent future folks from using the untyped version generateObject so folks use generateObjectV2 which is typesafe. Just a rename for now to reduce risk of regression. We will clean up old usages separately.

# Risks  
**Low**  
- Existing functionality will continue to work but will display a deprecation warning.  
- No impact on downstream systems expected.  
- Risk is isolated to developers relying on raw text-based JSON generation.

# Background  

## What does this PR do?  
This PR deprecates the text-based way of generating JSON objects using LLMs and so folks use generatedObjectV2 with typesafe structured outputs. Method isn't removed yet it is deprecated.

## What kind of change is this?  
- **Improvements**: Transitioning to a more robust way of handling JSON outputs.  
- **Chore**: Deprecation of legacy behavior.  

## Why are we doing this? Any context or related work?  
Text-based generation of JSON using LLMs is prone to errors like missing brackets, invalid types, or inconsistent structures. Moving to a typesafe structured output guarantees that JSON complies with predefined schemas, improving both developer experience and system stability.  

# Documentation changes needed?  
- **My changes require a change to the project documentation.**  
- Updated docs to:  
  - Reflect new structured output implementation.  
  - Mark text-based generation as deprecated.  

# Testing  

## Where should a reviewer start?  


## Detailed testing steps   
N/A just a rename
# Deploy Notes  
No special deployment steps required. 

# Database changes  
None.  

# Deployment instructions  
Standard deployment process applies.  

## Discord username  
0x8664

---  
