### PR TITLE
fix: revert llamacloud endpoint change

### DIFF
--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -118,7 +118,7 @@ export const models: Models = {
         imageSettings: {
             steps: 4,
         },
-        endpoint: "https://api.together.ai/v1",
+        endpoint: "https://api.llamacloud.com/v1",
         model: {
             [ModelClass.SMALL]: "meta-llama/Llama-3.2-3B-Instruct-Turbo",
             [ModelClass.MEDIUM]: "meta-llama-3.1-8b-instruct",


### PR DESCRIPTION
# Risks

Low: not sure if LlamaCloud has updated their URL recently

# Background

## What does this PR do?

reverts this seeming typo:

https://github.com/ai16z/eliza/commit/f3ca29902a9797eb991e4f7c07f69f5bd2914848#diff-126a0b18ab66588de8b33f8e6dc451651eb9fb5f7ab6d0c961a989b76f40be57L90

LlamaCloud probably should not be using together.ai's api endpoint

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A step in the right direction to fix llamacloud

# Documentation changes needed?

My changes do not require a change to the project documentation.
