### PR TITLE
fix(agent): correct EVM plugin activation condition

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -392,7 +392,7 @@ export function createAgent(
                 : null,
             getSecret(character, "EVM_PRIVATE_KEY") ||
             (getSecret(character, "WALLET_PUBLIC_KEY") &&
-                !getSecret(character, "WALLET_PUBLIC_KEY")?.startsWith("0x"))
+                getSecret(character, "WALLET_PUBLIC_KEY")?.startsWith("0x"))
                 ? evmPlugin
                 : null,
             getSecret(character, "ZEROG_PRIVATE_KEY") ? zgPlugin : null,


### PR DESCRIPTION
# Relates to:
Bug fix for EVM plugin activation logic

# Risks
Low 

# Background

## What does this PR do?
Fixes a logic bug in the EVM plugin activation condition where it was incorrectly checking for wallet addresses that do NOT start with '0x'. 

## What kind of change is this?
Bug fixes

# Documentation changes needed?

# Testing

## Where should a reviewer start?
Review the change in `agent/src/index.ts` where the EVM plugin activation condition is modified.

## Detailed testing steps

Code change:

```
// Before
getSecret(character, "EVM_PRIVATE_KEY") ||
(getSecret(character, "WALLET_PUBLIC_KEY") &&
!getSecret(character, "WALLET_PUBLIC_KEY")?.startsWith("0x"))
? evmPlugin
: null,

// After
getSecret(character, "EVM_PRIVATE_KEY") ||
(getSecret(character, "WALLET_PUBLIC_KEY") &&
getSecret(character, "WALLET_PUBLIC_KEY")?.startsWith("0x"))
? evmPlugin
: null,
```