### PR TITLE
Fix farcaster client process action issue

### DIFF
--- a/packages/client-farcaster/src/interactions.ts
+++ b/packages/client-farcaster/src/interactions.ts
@@ -35,7 +35,7 @@ export class FarcasterInteractionManager {
             try {
                 await this.handleInteractions();
             } catch (error) {
-                elizaLogger.error(error)
+                elizaLogger.error(error);
                 return;
             }
 
@@ -106,7 +106,7 @@ export class FarcasterInteractionManager {
                 agent,
                 cast: mention,
                 memory,
-                thread
+                thread,
             });
         }
 
@@ -117,15 +117,15 @@ export class FarcasterInteractionManager {
         agent,
         cast,
         memory,
-        thread
+        thread,
     }: {
         agent: Profile;
         cast: Cast;
         memory: Memory;
-        thread: Cast[]
+        thread: Cast[];
     }) {
         if (cast.profile.fid === agent.fid) {
-            elizaLogger.info("skipping cast from bot itself", cast.hash)
+            elizaLogger.info("skipping cast from bot itself", cast.hash);
             return;
         }
 
@@ -164,7 +164,7 @@ export class FarcasterInteractionManager {
             farcasterUsername: agent.username,
             timeline: formattedTimeline,
             currentPost,
-            formattedConversation
+            formattedConversation,
         });
 
         const shouldRespondContext = composeContext({
@@ -200,8 +200,13 @@ export class FarcasterInteractionManager {
             modelClass: ModelClass.SMALL,
         });
 
-        if (shouldRespondResponse === "IGNORE" || shouldRespondResponse === "STOP") {
-            elizaLogger.info(`Not responding to cast because generated ShouldRespond was ${shouldRespondResponse}`)
+        if (
+            shouldRespondResponse === "IGNORE" ||
+            shouldRespondResponse === "STOP"
+        ) {
+            elizaLogger.info(
+                `Not responding to cast because generated ShouldRespond was ${shouldRespondResponse}`
+            );
             return;
         }
 
@@ -223,7 +228,6 @@ export class FarcasterInteractionManager {
         response.inReplyTo = memoryId;
 
         if (!response.text) return;
-
 
         if (this.runtime.getSetting("FARCASTER_DRY_RUN") === "true") {
             elizaLogger.info(
@@ -247,6 +251,8 @@ export class FarcasterInteractionManager {
                     hash: cast.hash,
                 },
             });
+            // sendCast lost response action, so we need to add it back here
+            results[0].memory.content.action = response.action;
 
             const newState = await this.runtime.updateRecentMessageState(state);
 

--- a/packages/client-farcaster/src/interactions.ts
+++ b/packages/client-farcaster/src/interactions.ts
@@ -96,7 +96,7 @@ export class FarcasterInteractionManager {
             });
 
             const memory: Memory = {
-                content: { text: mention.text },
+                content: { text: mention.text, hash: mention.hash },
                 agentId: this.runtime.agentId,
                 userId,
                 roomId,


### PR DESCRIPTION
# Relates to:

Fix the bug where Farcaster client does NOT fire any actions

# Risks

Low
Only fixes action handling in existing functionality
No structural changes to the codebase
No database schema changes

# Background

## What does this PR do?

1. Fixes the bug where Farcaster client does not fire any actions
2. Adds cast hash to message memory for later use in action handler

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Currently, when the Farcaster client generates responses that should trigger actions (like following a user or reacting to a cast), these actions are not being executed. This happens because:

1. The action information is being lost during the response chain
2. The cast hash, which is necessary for some actions, is not properly stored in the message memory
3. The action handlers don't receive the complete context they need

This bug prevents important bot functionalities from working, such as:

- Automatic following of users who interact with the bot
- Reacting to casts when appropriate
- Any custom actions defined in the bot's behavior


# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. Review the changes in packages/client-farcaster/src/interactions.ts
2. Focus on the handleCast method where action handling is fixed

## Detailed testing steps

1. Set up a test Farcaster bot
2. Send a mention that should trigger an action
3. Verify that:
- The bot responds appropriately
- Actions are properly fired
- Cast hash is correctly stored in message memory
- Action handlers receive the necessary context

## Discord username
sin_bufan
