### PR TITLE
fix: docker trying to filter out missing docs package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY characters ./characters
 
 # Install dependencies and build the project
 RUN pnpm install \
-    && pnpm build \
+    && pnpm build-docker \
     && pnpm prune --prod
 
 # Create a new stage for the final image

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "scripts": {
         "preinstall": "npx only-allow pnpm",
         "build": "turbo run build --filter=!eliza-docs",
+        "build-docker": "turbo run build",
         "start": "pnpm --filter \"@ai16z/agent\" start --isRoot",
         "start:client": "pnpm --dir client start --isRoot",
         "start:debug": "cross-env NODE_ENV=development VERBOSE=true DEBUG=eliza:* pnpm --filter \"@ai16z/agent\" start --isRoot",


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

Fixes `pnpm docker` by adding a custom action for build for docker `block-docker`

Changed the `Dockerfile` to use this new action, which gets around the docs package not found when filtering.

This was the error
```
101.0 
101.0 > eliza@ build /app
101.0 > turbo run build --filter=!eliza-docs
101.0 
101.3 
101.3 Attention:
101.3 Turborepo now collects completely anonymous telemetry regarding usage.
101.3 This information is used to shape the Turborepo roadmap and prioritize features.
101.3 You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
101.3 https://turbo.build/repo/docs/telemetry
101.3 
101.3 turbo 2.3.3
101.3 
101.8   x No package found with name 'eliza-docs' in workspace
101.8 
101.8  ELIFECYCLE  Command failed with exit code 1.
------
```

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Neo reported an issue, confirmed issue on my server. Came up with this workaround.

# Documentation changes needed?

My changes do not require a change to the project documentation.