### PR TITLE
fix: Goat Plugin + AWS S3 Service error when env vars absent

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -371,12 +371,7 @@ export async function createAgent(
         character.name
     );
 
-    nodePlugin ??= (
-        getSecret(character, "AWS_ACCESS_KEY_ID") &&
-        getSecret(character, "AWS_SECRET_ACCESS_KEY") &&
-        getSecret(character, "AWS_REGION") &&
-        getSecret(character, "AWS_S3_BUCKET")
-    ) ? createNodePlugin() : undefined;
+    nodePlugin ??= createNodePlugin();
 
     const teeMode = getSecret(character, "TEE_MODE") || "OFF";
     const walletSecretSalt = getSecret(character, "WALLET_SECRET_SALT");

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -371,7 +371,12 @@ export async function createAgent(
         character.name
     );
 
-    nodePlugin ??= createNodePlugin();
+    nodePlugin ??= (
+        getSecret(character, "AWS_ACCESS_KEY_ID") &&
+        getSecret(character, "AWS_SECRET_ACCESS_KEY") &&
+        getSecret(character, "AWS_REGION") &&
+        getSecret(character, "AWS_S3_BUCKET")
+    ) ? createNodePlugin() : undefined;
 
     const teeMode = getSecret(character, "TEE_MODE") || "OFF";
     const walletSecretSalt = getSecret(character, "WALLET_SECRET_SALT");
@@ -384,9 +389,12 @@ export async function createAgent(
         throw new Error("Invalid TEE configuration");
     }
 
-    const goatPlugin = await createGoatPlugin((secret) =>
-        getSecret(character, secret)
-    );
+    let goatPlugin: any | undefined;
+    if (getSecret(character, "ALCHEMY_API_KEY")) {
+        goatPlugin = await createGoatPlugin((secret) =>
+            getSecret(character, secret)
+        );
+    }
 
     return new AgentRuntime({
         databaseAdapter: db,

--- a/packages/plugin-node/src/environment.ts
+++ b/packages/plugin-node/src/environment.ts
@@ -71,6 +71,15 @@ export async function validateNodeConfig(
             // VITS settings
             VITS_VOICE: voiceSettings?.model || process.env.VITS_VOICE,
             VITS_MODEL: process.env.VITS_MODEL,
+
+            // AWS settings (only include if present)
+            ...(runtime.getSetting("AWS_ACCESS_KEY_ID") && {
+                AWS_ACCESS_KEY_ID: runtime.getSetting("AWS_ACCESS_KEY_ID"),
+                AWS_SECRET_ACCESS_KEY: runtime.getSetting("AWS_SECRET_ACCESS_KEY"),
+                AWS_REGION: runtime.getSetting("AWS_REGION"),
+                AWS_S3_BUCKET: runtime.getSetting("AWS_S3_BUCKET"),
+                AWS_S3_UPLOAD_PATH: runtime.getSetting("AWS_S3_UPLOAD_PATH"),
+            }),
         };
 
         return nodeEnvSchema.parse(config);


### PR DESCRIPTION

<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

https://github.com/ai16z/eliza/pull/941 and https://github.com/ai16z/eliza/pull/898

Errors when running agent were:
`TypeError: Cannot read properties of null (reading 'getChain')`

```

 ["✓ Service video initialized successfully"] 

Initializing AwsS3Service
 ⛔ ERRORS
   Failed to initialize service aws_s3: 
   {} 

 ⛔ ERRORS
   Error starting agent for character trump: 
   {} 

Error: Missing required AWS credentials in environment variables
    at _AwsS3Service.initialize (file:///home/jnaulty/github.com/ai16z/eliza/packages/plugin-node/dist/index.js:1890:19)
    at AgentRuntime.initialize (file:///home/jnaulty/github.com/ai16z/eliza/packages/core/dist/index.js:3245:31)
    at async startAgent (file:///home/jnaulty/github.com/ai16z/eliza/agent/src/index.ts:344:9)
    at async startAgents (file:///home/jnaulty/github.com/ai16z/eliza/agent/src/index.ts:368:13)
 ⛔ ERRORS
   Error starting agents: 
   {} 

 ["◎ Chat started. Type 'exit' to quit."] 

You:  ["✓ Server running at http://localhost:3000/"] 
```



# Risks

* none, improves usability when specific env variables are not present

# Background

## What does this PR do?

* fixes issue when environment variables are not set for goat + node plugins

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)



## Why are we doing this? Any context or related work?

* main branch does not run unless AWS env variables are set and Alchemy API (for GOAT)
* - NodePlugin is now only created when all required AWS credentials are present (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_S3_BUCKET)
- GoatPlugin is now only created when ALCHEMY_API_KEY is present
- Added type annotations for plugins to handle undefined cases

These changes prevent unnecessary plugin initialization when required credentials are missing and improve type safety.

Issues introduced in: https://github.com/ai16z/eliza/pull/941 and https://github.com/ai16z/eliza/pull/898

# Documentation changes needed?

none

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested, and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

None, automated tests are fine.



<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deploy, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste commandline output. -->
<!--
## Database changes
-->

<!--  If there is something more than the automated steps, please specifiy deploy instructions. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for contribute role and join us in #development-feed -->
## Discord username
@crypto__john
