### PR TITLE
feat: create example folder with example plugin

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "version": "0.1.5-alpha.5",
-    "packages": ["packages/*", "docs", "agent", "client"],
+    "packages": ["packages/*", "docs", "agent", "client", "!packages/_examples"],
     "npmClient": "pnpm"
 }

--- a/packages/_examples/plugin/.npmignore
+++ b/packages/_examples/plugin/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!dist/**
+!package.json
+!readme.md
+!tsup.config.ts

--- a/packages/_examples/plugin/README.md
+++ b/packages/_examples/plugin/README.md
@@ -1,0 +1,32 @@
+# Sample Plugin for Eliza
+
+The Sample Plugin for Eliza extends the functionality of the Eliza platform by providing additional actions, providers, evaluators, and more. This plugin is designed to be easily extendable and customizable to fit various use cases.
+
+## Description
+The Sample Plugin offers a set of features that can be integrated into the Eliza platform to enhance its capabilities. Below is a high-level overview of the different components available in this plugin.
+
+## Actions
+- **createResourceAction**: This action enables the creation and management of generic resources. It can be customized to handle different types of resources and integrate with various data sources.
+
+## Providers
+- **sampleProvider**: This provider offers a mechanism to supply data or services to the plugin. It can be extended to include additional providers as needed.
+
+## Evaluators
+- **sampleEvaluator**: This evaluator provides a way to assess or analyze data within the plugin. It can be extended to include additional evaluators as needed.
+
+## Services
+- **[ServiceName]**: Description of the service and its functionality. This can be extended to include additional services as needed.
+
+## Clients
+- **[ClientName]**: Description of the client and its functionality. This can be extended to include additional clients as needed.
+
+## How to Extend
+To extend the Sample Plugin, you can add new actions, providers, evaluators, services, and clients by following the structure provided in the plugin. Each component can be customized to fit your specific requirements.
+
+1. **Actions**: Add new actions by defining them in the `actions` array.
+2. **Providers**: Add new providers by defining them in the `providers` array.
+3. **Evaluators**: Add new evaluators by defining them in the `evaluators` array.
+4. **Services**: Add new services by defining them in the `services` array.
+5. **Clients**: Add new clients by defining them in the `clients` array.
+
+For more detailed information on how to extend the plugin, refer to the documentation provided in the Eliza platform.

--- a/packages/_examples/plugin/eslint.config.mjs
+++ b/packages/_examples/plugin/eslint.config.mjs
@@ -1,0 +1,3 @@
+import eslintGlobalConfig from "../../eslint.config.mjs";
+
+export default [...eslintGlobalConfig];

--- a/packages/_examples/plugin/package.json
+++ b/packages/_examples/plugin/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "@ai16z/plugin-sample",
+    "version": "0.1.5-alpha.5",
+    "main": "dist/index.js",
+    "type": "module",
+    "types": "dist/index.d.ts",
+    "dependencies": {
+        "@ai16z/eliza": "workspace:*"
+    },
+    "devDependencies": {
+        "tsup": "8.3.5",
+        "@types/node": "^20.0.0"
+    },
+    "scripts": {
+        "build": "tsup --format esm --dts",
+        "dev": "tsup --format esm --dts --watch",
+        "lint": "eslint . --fix"
+    }
+}

--- a/packages/_examples/plugin/src/actions/sampleAction.ts
+++ b/packages/_examples/plugin/src/actions/sampleAction.ts
@@ -1,0 +1,117 @@
+import {
+    Action,
+    IAgentRuntime,
+    Memory,
+    HandlerCallback,
+    State,
+    composeContext,
+    generateObjectV2,
+    ModelClass,
+    elizaLogger,
+} from "@ai16z/eliza";
+
+import {
+    CreateResourceSchema,
+    isCreateResourceContent,
+} from "../types";
+
+import { createResourceTemplate } from "../templates";
+
+export const createResourceAction: Action = {
+    name: "CREATE_RESOURCE",
+    description: "Create a new resource with the specified details",
+    validate: async (runtime: IAgentRuntime, _message: Memory) => {
+        return !!(runtime.character.settings.secrets?.API_KEY);
+    },
+    handler: async (
+        runtime: IAgentRuntime,
+        _message: Memory,
+        state: State,
+        _options: any,
+        callback: HandlerCallback
+    ) => {
+    try {
+        const context = composeContext({
+            state,
+            template: createResourceTemplate,
+        });
+
+        const resourceDetails = await generateObjectV2({
+            runtime,
+            context,
+            modelClass: ModelClass.SMALL,
+            schema: CreateResourceSchema,
+        });
+
+        if (!isCreateResourceContent(resourceDetails.object)) {
+            callback(
+                { text: "Invalid resource details provided." },
+                []
+            );
+            return;
+        }
+
+        // persist relevant data if needed to memory/knowledge
+        // const memory = {
+        //     type: "resource",
+        //     content: resourceDetails.object,
+        //     timestamp: new Date().toISOString()
+        // };
+
+        // await runtime.storeMemory(memory);
+
+        callback(
+            {
+                text: `Resource created successfully:
+- Name: ${resourceDetails.object.name}
+- Type: ${resourceDetails.object.type}
+- Description: ${resourceDetails.object.description}
+- Tags: ${resourceDetails.object.tags.join(", ")}
+
+Resource has been stored in memory.`
+            },
+            []
+        );
+    } catch (error) {
+        elizaLogger.error("Error creating resource:", error);
+        callback(
+            { text: "Failed to create resource. Please check the logs." },
+            []
+        );
+    }
+    },
+    examples: [
+    [
+        {
+            user: "{{user1}}",
+            content: {
+                text: "Create a new resource with the name 'Resource1' and type 'TypeA'",
+            },
+        },
+        {
+            user: "{{agentName}}",
+            content: {
+                text: `Resource created successfully:
+- Name: Resource1
+- Type: TypeA`,
+            },
+        },
+    ],
+    [
+        {
+            user: "{{user1}}",
+            content: {
+                text: "Create a new resource with the name 'Resource2' and type 'TypeB'",
+            },
+        },
+        {
+            user: "{{agentName}}",
+            content: {
+                text: `Resource created successfully:
+- Name: Resource2
+- Type: TypeB`,
+            },
+        },
+    ],
+    ],
+};

--- a/packages/_examples/plugin/src/evaluators/sampleEvalutor.ts
+++ b/packages/_examples/plugin/src/evaluators/sampleEvalutor.ts
@@ -1,0 +1,47 @@
+import { Evaluator, IAgentRuntime, Memory, State, elizaLogger } from "@ai16z/eliza";
+
+export const sampleEvaluator: Evaluator = {
+    alwaysRun: false,
+    description: "Sample evaluator for checking important content in memory",
+    similes: ["content checker", "memory evaluator"],
+    examples: [
+        {
+            context: "Checking if memory contains important content",
+            messages: [
+                {
+                    action: "evaluate",
+                    input: "This is an important message",
+                    output: {
+                        score: 1,
+                        reason: "Memory contains important content."
+                    }
+                }
+            ],
+            outcome: "Memory should be evaluated as important"
+        }
+    ],
+    handler: async (runtime: IAgentRuntime, memory: Memory, state: State) => {
+        // Evaluation logic for the evaluator
+        elizaLogger.log("Evaluating data in sampleEvaluator...");
+
+        // Example evaluation logic
+        if (memory.content && memory.content.includes("important")) {
+            elizaLogger.log("Important content found in memory.");
+            return {
+                score: 1,
+                reason: "Memory contains important content."
+            };
+        } else {
+            elizaLogger.log("No important content found in memory.");
+            return {
+                score: 0,
+                reason: "Memory does not contain important content."
+            };
+        }
+    },
+    name: "sampleEvaluator",
+    validate: async (runtime: IAgentRuntime, memory: Memory, state: State) => {
+        // Validation logic for the evaluator
+        return true;
+    }
+};

--- a/packages/_examples/plugin/src/index.ts
+++ b/packages/_examples/plugin/src/index.ts
@@ -1,0 +1,8 @@
+import { samplePlugin } from './plugins/samplePlugin';
+
+
+
+export * from './plugins/samplePlugin';
+
+
+export default samplePlugin;

--- a/packages/_examples/plugin/src/plugins/samplePlugin.ts
+++ b/packages/_examples/plugin/src/plugins/samplePlugin.ts
@@ -1,0 +1,17 @@
+import {
+    Plugin,
+} from "@ai16z/eliza";
+import { createResourceAction } from "../actions/sampleAction";
+import { sampleProvider } from "../providers/sampleProvider";
+import { sampleEvaluator } from "../evaluators/sampleEvalutor";
+
+export const samplePlugin: Plugin = {
+    name: "sample",
+    description: "Enables creation and management of generic resources",
+    actions: [createResourceAction],
+    providers: [sampleProvider],
+    evaluators: [sampleEvaluator],
+    // separate examples will be added for services and clients
+    services: [],
+    clients: [],
+};

--- a/packages/_examples/plugin/src/providers/sampleProvider.ts
+++ b/packages/_examples/plugin/src/providers/sampleProvider.ts
@@ -1,0 +1,14 @@
+import {
+    Provider,
+    IAgentRuntime,
+    Memory,
+    State,
+    elizaLogger
+} from "@ai16z/eliza";
+
+export const sampleProvider: Provider = {
+    get: async (runtime: IAgentRuntime, message: Memory, state: State) => {
+        // Data retrieval logic for the provider
+        elizaLogger.log("Retrieving data in sampleProvider...");
+    },
+};

--- a/packages/_examples/plugin/src/templates.ts
+++ b/packages/_examples/plugin/src/templates.ts
@@ -1,0 +1,60 @@
+export const createResourceTemplate = `
+Extract the following details to create a new resource:
+- **name** (string): Name of the resource
+- **type** (string): Type of resource (document, image, video)
+- **description** (string): Description of the resource
+- **tags** (array): Array of tags to categorize the resource
+
+Provide the values in the following JSON format:
+
+\`\`\`json
+{
+    "name": "<resource_name>",
+    "type": "<resource_type>",
+    "description": "<resource_description>",
+    "tags": ["<tag1>", "<tag2>"]
+}
+\`\`\`
+
+Here are the recent user messages for context:
+{{recentMessages}}
+`;
+
+export const readResourceTemplate = `
+Extract the following details to read a resource:
+- **id** (string): Unique identifier of the resource
+- **fields** (array): Specific fields to retrieve (optional)
+
+Provide the values in the following JSON format:
+
+\`\`\`json
+{
+    "id": "<resource_id>",
+    "fields": ["<field1>", "<field2>"]
+}
+\`\`\`
+
+Here are the recent user messages for context:
+{{recentMessages}}
+`;
+
+export const updateResourceTemplate = `
+Extract the following details to update a resource:
+- **id** (string): Unique identifier of the resource
+- **updates** (object): Key-value pairs of fields to update
+
+Provide the values in the following JSON format:
+
+\`\`\`json
+{
+    "id": "<resource_id>",
+    "updates": {
+        "<field1>": "<new_value1>",
+        "<field2>": "<new_value2>"
+    }
+}
+\`\`\`
+
+Here are the recent user messages for context:
+{{recentMessages}}
+`;

--- a/packages/_examples/plugin/src/types.ts
+++ b/packages/_examples/plugin/src/types.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+// Base resource schema
+export const ResourceSchema = z.object({
+    id: z.string().optional(),
+    name: z.string().min(1),
+    type: z.enum(["document", "image", "video"]),
+    description: z.string(),
+    tags: z.array(z.string())
+});
+
+// Create resource schema
+export const CreateResourceSchema = ResourceSchema.omit({ id: true });
+
+// Read resource schema
+export const ReadResourceSchema = z.object({
+    id: z.string(),
+    fields: z.array(z.string()).optional()
+});
+
+// Update resource schema
+export const UpdateResourceSchema = z.object({
+    id: z.string(),
+    updates: z.record(z.string(), z.any())
+});
+
+// Type definitions
+export type Resource = z.infer<typeof ResourceSchema>;
+export type CreateResourceContent = z.infer<typeof CreateResourceSchema>;
+export type ReadResourceContent = z.infer<typeof ReadResourceSchema>;
+export type UpdateResourceContent = z.infer<typeof UpdateResourceSchema>;
+
+// Type guards
+export const isCreateResourceContent = (obj: any): obj is CreateResourceContent => {
+    return CreateResourceSchema.safeParse(obj).success;
+};
+
+export const isReadResourceContent = (obj: any): obj is ReadResourceContent => {
+    return ReadResourceSchema.safeParse(obj).success;
+};
+
+export const isUpdateResourceContent = (obj: any): obj is UpdateResourceContent => {
+    return UpdateResourceSchema.safeParse(obj).success;
+};
+
+// Plugin configuration type
+export interface ExamplePluginConfig {
+    apiKey: string;
+    apiSecret: string;
+    endpoint?: string;
+}

--- a/packages/_examples/plugin/tsconfig.json
+++ b/packages/_examples/plugin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../core/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "types": [
+            "node"
+        ]
+    },
+    "include": [
+        "src/**/*.ts",
+    ]
+}

--- a/packages/_examples/plugin/tsup.config.ts
+++ b/packages/_examples/plugin/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/index.ts"],
+    outDir: "dist",
+    sourcemap: true,
+    clean: true,
+    format: ["esm"], // Ensure you're targeting CommonJS
+    external: [
+        "dotenv", // Externalize dotenv to prevent bundling
+        "fs", // Externalize fs to use Node.js built-in module
+        "path", // Externalize other built-ins if necessary
+        "@reflink/reflink",
+        "@node-llama-cpp",
+        "https",
+        "http",
+        "agentkeepalive",
+        "safe-buffer",
+        // Add other modules you want to externalize
+    ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,7 +585,7 @@ importers:
         version: 8.57.1
       jest:
         specifier: ^29.0.0
-        version: 29.7.0(@types/node@20.17.9)
+        version: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
       typescript:
         specifier: ^5.0.0
         version: 5.6.3
@@ -1042,7 +1042,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.8.4)
+        version: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
       tsup:
         specifier: 8.3.5
         version: 8.3.5(@swc/core@1.10.1(@swc/helpers@0.5.15))(jiti@2.4.0)(postcss@8.4.49)(typescript@5.6.3)(yaml@2.6.1)
@@ -1447,10 +1447,10 @@ importers:
         version: 8.16.0(eslint@9.16.0(jiti@2.4.0))(typescript@5.6.3)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.17.9)
+        version: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
       ts-jest:
         specifier: 29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.9))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3)))(typescript@5.6.3)
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -20864,6 +20864,41 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.17.9
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
@@ -26704,13 +26739,13 @@ snapshots:
       ripemd160: 2.0.2
       sha.js: 2.4.11
 
-  create-jest@29.7.0(@types/node@20.17.9):
+  create-jest@29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -28214,7 +28249,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.0(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -29830,35 +29865,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.17.9):
+  jest-cli@29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.17.9)
+      create-jest: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@29.7.0(@types/node@22.8.4):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -29886,6 +29902,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3)):
+    dependencies:
+      '@babel/core': 7.26.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.17.9
+      ts-node: 10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3)):
     dependencies:
@@ -30170,24 +30217,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.17.9):
+  jest@29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.17.9)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@22.8.4):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.8.4)
+      jest-cli: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -35670,12 +35705,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.9))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.17.9)
+      jest: 29.7.0(@types/node@20.17.9)(ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -35709,6 +35744,27 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.26.0)
 
   ts-mixer@6.0.4: {}
+
+  ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@20.17.9)(typescript@5.6.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.17.9
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.10.1(@swc/helpers@0.5.15)
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.10.1(@swc/helpers@0.5.15))(@types/node@22.8.4)(typescript@5.6.3):
     dependencies:


### PR DESCRIPTION
# Relates to:
Initial setup of example plugin structure, to come examples of adapters, clients, services, etc. This will make it easier to standardize development, best practices, code review, and ultimately quality of the repo.

# Risks
Low - This is an example plugin that serves as a template/reference implementation

# Background

## What does this PR do?
Creates an example plugin folder with a sample implementation including:
- Basic plugin structure
- Sample actions, providers, and evaluators
- TypeScript configuration
- Build setup with tsup
- NPM package configuration

## What kind of change is this?
Features (non-breaking change which adds functionality)

# Documentation changes needed?
My changes do require a change to the project documentation which is included. Will update the global readme once all examples are added.

# Testing

## Where should a reviewer start?
1. Review the plugin structure in `packages/_examples/plugin/`
2. Key files to review:
   - `src/plugins/samplePlugin.ts` - Main plugin definition
   - `src/actions/sampleAction.ts` - Example action implementation
   - `src/providers/sampleProvider.ts` - Example provider implementation
   - `src/evaluators/sampleEvaluator.ts` - Example evaluator implementation

## Detailed testing steps
1. Navigate to the plugin directory: