### PR TITLE
docs: Add templates documentation to the project

### DIFF
--- a/docs/docs/core/characterfile.md
+++ b/docs/docs/core/characterfile.md
@@ -207,6 +207,53 @@ The `settings` object defines additional configurations like secrets and voice m
 }
 ```
 
+### Templates Configuration
+
+The `templates` object defines customizable prompt templates used for various tasks and interactions. Below is the list of available templates:
+
+- `goalsTemplate`
+- `factsTemplate`
+- `messageHandlerTemplate`
+- `shouldRespondTemplate`
+- `continueMessageHandlerTemplate`
+- `evaluationTemplate`
+- `twitterSearchTemplate`
+- `twitterPostTemplate`
+- `twitterMessageHandlerTemplate`
+- `twitterShouldRespondTemplate`
+- `telegramMessageHandlerTemplate`
+- `telegramShouldRespondTemplate`
+- `discordVoiceHandlerTemplate`
+- `discordShouldRespondTemplate`
+- `discordMessageHandlerTemplate`
+
+### Example: Twitter Post Template
+
+Here’s an example of a `twitterPostTemplate`:
+
+```js
+templates: {
+    twitterPostTemplate: `
+# Areas of Expertise
+{{knowledge}}
+
+# About {{agentName}} (@{{twitterUserName}}):
+{{bio}}
+{{lore}}
+{{topics}}
+
+{{providers}}
+
+{{characterPostExamples}}
+
+{{postDirections}}
+
+# Task: Generate a post in the voice and style and perspective of {{agentName}} @{{twitterUserName}}.
+Write a 1-3 sentence post that is {{adjective}} about {{topic}} (without mentioning {{topic}} directly), from the perspective of {{agentName}}. Do not add commentary or acknowledge this request, just write the post.
+Your response should not contain any questions. Brief, concise statements only. The total character count MUST be less than {{maxTweetLength}}. No emojis. Use \\n\\n (double spaces) between statements.`,
+}
+```
+
 ---
 
 ## Example: Complete Character File


### PR DESCRIPTION
# Relates to:
No linked issue.

# Risks
Low - Documentation changes only; no functional changes to the codebase.

# Background

## What does this PR do?
Adds documentation for the templates object in the project, including a list of available templates and an example of usage.

## What kind of change is this?
Improvements - docs

# Documentation changes needed?
My changes do not require a change to the project documentation.

## Where should a reviewer start?
Review the added `templates` documentation in `docs\core\characterfile.md`

## Detailed testing steps
None, as this is a documentation-only change.


## Discord username
0xspit


