### PR TITLE
fix: discord client duplicate function removal

### DIFF
--- a/packages/client-discord/src/messages.ts
+++ b/packages/client-discord/src/messages.ts
@@ -687,47 +687,6 @@ export class MessageManager {
         );
     }
 
-    private _isMessageForMe(message: DiscordMessage): boolean {
-        const isMentioned = message.mentions.users?.has(
-            this.client.user?.id as string
-        );
-        const guild = message.guild;
-        const member = guild?.members.cache.get(this.client.user?.id as string);
-        const nickname = member?.nickname;
-
-        // Don't consider role mentions as direct mentions
-        const hasRoleMentionOnly =
-            message.mentions.roles.size > 0 && !isMentioned;
-
-        // If it's only a role mention and we're in team mode, let team logic handle it
-        if (
-            hasRoleMentionOnly &&
-            this.runtime.character.clientConfig?.discord?.isPartOfTeam
-        ) {
-            return false;
-        }
-
-        return (
-            isMentioned ||
-            (!this.runtime.character.clientConfig?.discord
-                ?.shouldRespondOnlyToMentions &&
-                (message.content
-                    .toLowerCase()
-                    .includes(
-                        this.client.user?.username.toLowerCase() as string
-                    ) ||
-                    message.content
-                        .toLowerCase()
-                        .includes(
-                            this.client.user?.tag.toLowerCase() as string
-                        ) ||
-                    (nickname &&
-                        message.content
-                            .toLowerCase()
-                            .includes(nickname.toLowerCase()))))
-        );
-    }
-
     private async _analyzeContextSimilarity(
         currentMessage: string,
         previousContext?: MessageContext,
@@ -1218,7 +1177,7 @@ export class MessageManager {
                 return false;
             }
         }
-          
+
         if (message.mentions.has(this.client.user?.id as string)) return true;
 
         const guild = message.guild;


### PR DESCRIPTION
# Relates to:
N/A
# Risks

Low - Removing duplicate function.

# Background

## What does this PR do?

## What kind of change is this?

Bug fix - Removing duplicate _isMessageForMe private function in Discord messages.ts file.


<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

N/A

# Testing

## Where should a reviewer start?

## Detailed testing steps

Review messages.ts in discord-client to confirm only 1 private _isMessageForMe now exists with same functionality to avoid issues.

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
N/A

<!--
# Deploy Notes
-->
N/A

<!--
## Database changes
-->
N/A

<!--
## Deployment instructions
-->
N/A

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for contribute role and join us in #development-feed -->
<!--
## Discord username

-->
