### PR TITLE
fix: telegram client duplicate function removal

### DIFF
--- a/packages/client-telegram/src/messageManager.ts
+++ b/packages/client-telegram/src/messageManager.ts
@@ -322,11 +322,14 @@ export class MessageManager {
                            'caption' in message ? (message as any).caption : '';
         if (!messageText) return false;
 
+        const isReplyToBot = (message as any).reply_to_message?.from?.is_bot === true &&
+                        (message as any).reply_to_message?.from?.username === botUsername;
         const isMentioned = messageText.includes(`@${botUsername}`);
         const hasUsername = messageText.toLowerCase().includes(botUsername.toLowerCase());
 
-        return isMentioned || (!this.runtime.character.clientConfig?.telegram?.shouldRespondOnlyToMentions && hasUsername);
+        return isReplyToBot || isMentioned || (!this.runtime.character.clientConfig?.telegram?.shouldRespondOnlyToMentions && hasUsername);
     }
+
 
     private _checkInterest(chatId: string): boolean {
         const chatState = this.interestChats[chatId];
@@ -358,22 +361,6 @@ export class MessageManager {
         }
 
         return true;
-    }
-
-    private _isMessageForMe(message: Message): boolean {
-        const botUsername = this.bot.botInfo?.username;
-        if (!botUsername) return false;
-
-        const messageText = 'text' in message ? message.text :
-                           'caption' in message ? (message as any).caption : '';
-        if (!messageText) return false;
-      
-        const isReplyToBot = (message as any).reply_to_message?.from?.is_bot === true &&
-                        (message as any).reply_to_message?.from?.username === botUsername;
-        const isMentioned = messageText.includes(`@${botUsername}`);
-        const hasUsername = messageText.toLowerCase().includes(botUsername.toLowerCase());
-
-        return isReplyToBot || isMentioned || (!this.runtime.character.clientConfig?.telegram?.shouldRespondOnlyToMentions && hasUsername);
     }
 
     // Process image messages and generate descriptions
@@ -422,7 +409,7 @@ export class MessageManager {
         message: Message,
         state: State
     ): Promise<boolean> {
-         
+
         if (this.runtime.character.clientConfig?.telegram?.shouldRespondOnlyToMentions) {
             return this._isMessageForMe(message);
         }


### PR DESCRIPTION
# Relates to:
N/A
# Risks

Low - Removing duplicate function.

# Background

## What does this PR do?

## What kind of change is this?

Bug fix - Removing duplicate _isMessageForMe private function in Telegram messages.ts file.


<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

N/A

# Testing

## Where should a reviewer start?

## Detailed testing steps

Review messageManager.ts in telegram-client to confirm only 1 private _isMessageForMe now exists with same functionality to avoid issues.

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
N/A

<!--
# Deploy Notes
-->
N/A

<!--
## Database changes
-->
N/A

<!--
## Deployment instructions
-->
N/A

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for contribute role and join us in #development-feed -->
<!--
## Discord username

-->
