### PR TITLE
clean newlines for new tweet

### DIFF
--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -273,8 +273,11 @@ export class TwitterPostClient {
             const removeQuotes = (str: string) =>
                 str.replace(/^['"](.*)['"]$/, "$1");
 
+            const fixNewLines = (str: string) =>
+                str.replaceAll(/\\n/g, "\n");
+
             // Final cleaning
-            cleanedContent = removeQuotes(content);
+            cleanedContent = removeQuotes(fixNewLines(content));
 
             if (this.runtime.getSetting("TWITTER_DRY_RUN") === "true") {
                 elizaLogger.info(


### PR DESCRIPTION
# Relates to:

New tweet being created with `\n` text instead of new line

# Risks

No risks

# Background

## What does this PR do?

Improves tweet creation script. Make sure none `\n` are inside newly published tweet.

## What kind of change is this?

**Improvement.** This logic is already there inside `generateTweetContent` however it's not included inside `generateNewTweet`. It could use a little more refactor but right now I'm just posting this as an easy fix.

## Why are we doing this? Any context or related work?

I'm playing around with eliza and my twitter account and saw that it posted tweet with `\n \n` inside which I don't think is what AI beneath intended :)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

I looked at the logs and inserted the cleanup function right before it's submitted to twitter. I'm attaching screenshot from logs to see my reasoning 
<img width="473" alt="image" src="https://github.com/user-attachments/assets/b31becb8-9d08-4062-b6c2-b87fc8960626" />

## Where should a reviewer start?

Quite simple change

## Detailed testing steps

None, automated tests are fine.

## Discord username
elowielo

