### PR TITLE
docs(readme): add bash code block for all bash scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ git checkout $(git describe --tags --abbrev=0)
 
 Copy .env.example to .env and fill in the appropriate values.
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -115,7 +115,7 @@ pnpm clean
 
 You may need to install Sharp. If you see an error when starting up, try installing it with the following command:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -31,7 +31,7 @@
 
 ## (A) 使用启动器(Starter): 推荐
 
-```
+```bash
 git clone https://github.com/ai16z/eliza-starter.git
 cd eliza-starter
 cp .env.example .env
@@ -39,7 +39,7 @@ cp .env.example .env
 
 ## (B) 手动启动Eliza: 仅在您知道自己在做什么时才推荐
 
-```
+```bash
 git clone https://github.com/ai16z/eliza.git
 cd eliza
 # 切换最新发布的版本(Checkout the latest release)
@@ -116,7 +116,7 @@ pnpm start
 
 您可能需要安装 Sharp。如果在启动时看到错误，请尝试使用以下命令安装：
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -69,7 +69,7 @@ git checkout $(git describe --tags --abbrev=0)
 
 Kopiere .env.example nach .env und fülle die entsprechenden Werte aus.
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -108,7 +108,7 @@ pnpm clean
 
 Möglicherweise musst du Sharp installieren. Wenn beim Starten ein Fehler auftritt, versuche es mit folgendem Befehl:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -39,7 +39,7 @@
 
 Después de configurar el archivo .env y el archivo de personaje, puede iniciar el bot con:
 
-```
+```bash
 pnpm i
 pnpm start
 ```
@@ -68,7 +68,7 @@ Puede ejecutar modelos OpenAI configurando la variable de ambiente `XAI_MODEL` e
 
 Puede ser necesario instalar Sharp. Si encuentra un error al iniciar, intente instalarlo con:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 
@@ -137,7 +137,7 @@ TOGETHER_API_KEY=
 
 Si tiene una GPU NVIDIA, puede instalar CUDA para acelerar significativamente la inferencia local.
 
-```
+```bash
 pnpm install
 npx --no node-llama-cpp source download --gpu cuda
 ```

--- a/README_FR.md
+++ b/README_FR.md
@@ -34,7 +34,7 @@ Que pouvez-vous faire avec Eliza?
 
 -   Copier le fichier d'example et le remplir le avec les valeurs adéquates
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -64,7 +64,7 @@ pnpm clean
 Il vous faudra peut-être installer Sharp.
 Si il y a une erreur lors du lancement du bot, essayez d'installer Sharp comme ceci :
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_HE.md
+++ b/README_HE.md
@@ -72,7 +72,7 @@
 
 <div align="right" dir="ltr">
 
-```
+```bash
 git clone https://github.com/ai16z/eliza-starter.git
 
 cp .env.example .env
@@ -88,7 +88,7 @@ pnpm i && pnpm start
 ### התחלה ידנית של אלייזה (מומלץ רק למי שיודע מה הוא עושה)
 <div align="right">
 
-```
+```bash
 # שכפול המאגר
 git clone https://github.com/ai16z/eliza.git
 
@@ -100,7 +100,6 @@ git checkout $(git describe --tags --abbrev=0)
 ### התחלת אלייזה עם Gitpod
 
 <div align="right">
-
 [![פתח ב-Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/ai16z/eliza/tree/main)
 
 </div>
@@ -111,7 +110,7 @@ git checkout $(git describe --tags --abbrev=0)
 
 העתק את .env.example ל-.env ומלא את הערכים המתאימים.
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -159,7 +158,7 @@ pnpm clean
 
 ייתכן שתצטרך להתקין את Sharp. אם אתה רואה שגיאה בעת ההפעלה, נסה להתקין עם הפקודה הבאה:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_IT.md
+++ b/README_IT.md
@@ -37,7 +37,7 @@
 
 Copia .env.example in .env e inserisci i valori appropriati
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -72,7 +72,7 @@ pnpm clean
 
 Potrebbe essere necessario installare Sharp. Se vedi un errore all'avvio, prova a installarlo con il seguente comando:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -38,7 +38,7 @@
 
 .envファイルとキャラクターファイルを設定した後、以下のコマンドでボットを起動可能:
 
-```
+```bash
 pnpm i
 pnpm start
 ```
@@ -67,7 +67,7 @@ pnpm start
 
 Sharpをインストールする必要があるかもしれません。起動時にエラーが表示された場合は、以下のコマンドでインストールを試みてください:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 
@@ -137,7 +137,7 @@ TOGETHER_API_KEY=
 
 NVIDIA GPUを持っている場合、CUDAをインストールしてローカル推論を大幅に高速化可能
 
-```
+```bash
 pnpm install
 npx --no node-llama-cpp source download --gpu cuda
 ```

--- a/README_KOR.md
+++ b/README_KOR.md
@@ -70,7 +70,7 @@ git checkout $(git describe --tags --abbrev=0)
 
 .env.example을 복사해서 필요한 값들을 채워넣어 .env파일을 만드세요.
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -108,7 +108,7 @@ pnpm clean
 
 시작 시 에러가 발생하면 Sharp를 설치해야 할 수 있습니다. 아래 명령어를 사용하여 설치하세요:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_PTBR.md
+++ b/README_PTBR.md
@@ -39,7 +39,7 @@
 
 Após configurar o arquivo .env e o arquivo de personagem, você pode iniciar o bot com o seguinte comando:
 
-```
+```bash
 pnpm i
 pnpm start
 ```
@@ -68,7 +68,7 @@ Você pode executar modelos OpenAI configurando a variável de ambiente `XAI_MOD
 
 Pode ser necessário instalar o Sharp. Se você encontrar um erro ao iniciar, tente instalá-lo com o seguinte comando:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 
@@ -139,7 +139,7 @@ TOGETHER_API_KEY=
 
 Se você tiver uma GPU NVIDIA, pode instalar o CUDA para acelerar dramaticamente a inferência local.
 
-```
+```bash
 pnpm install
 npx --no node-llama-cpp source download --gpu cuda
 ```

--- a/README_TH.md
+++ b/README_TH.md
@@ -70,7 +70,7 @@ git checkout $(git describe --tags --abbrev=0)
 
 คัดลอก .env.example ไปเป็น .env และระบุค่าที่เหมาะสม
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -110,7 +110,7 @@ pnpm clean
 
 คุณอาจต้องติดตั้ง Sharp ถ้าหากคุณเห็นข้อความ error เมื่อเริ่มต้น สามารถลองติดตั้งด้วยคำสั่งต่อไปนี้:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_TR.md
+++ b/README_TR.md
@@ -5,9 +5,9 @@
 </div>
 
 <div align="center">
-  
+
   📖 [Dokümantasyon](https://ai16z.github.io/eliza/) | 🎯 [Örnekler](https://github.com/thejoven/awesome-eliza)
-  
+
 </div>
 
 ## ✨ Özellikler
@@ -43,7 +43,7 @@
 
 .env.example dosyasını .env olarak kopyalayın ve uygun değerleri doldurun
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -72,7 +72,7 @@ pnpm clean
 
 Sharp'ı yüklemeniz gerekebilir. Başlatma sırasında bir hata görürseniz, aşağıdaki komutla yüklemeyi deneyin:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 

--- a/README_VI.md
+++ b/README_VI.md
@@ -70,7 +70,7 @@ git checkout $(git describe --tags --abbrev=0)
 
 Sao chép .env.example vào .env và điền các giá trị thích hợp.
 
-```
+```bash
 cp .env.example .env
 ```
 
@@ -109,7 +109,7 @@ pnpm clean
 
 Bạn có thể cần cài đặt Sharp. Nếu bạn thấy lỗi khi khởi động, hãy thử cài đặt bằng lệnh sau:
 
-```
+```bash
 pnpm install --include=optional sharp
 ```
 


### PR DESCRIPTION
Add `bash` code block for all the bash scripts, better to markdown rendering
