### PR TITLE
fix: Fix local_llama key warning

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -210,8 +210,11 @@ export async function loadCharacters(
 export function getTokenForProvider(
     provider: ModelProviderName,
     character: Character
-) {
+):string {
     switch (provider) {
+        // no key needed for llama_local
+        case ModelProviderName.LLAMALOCAL:
+            return ''
         case ModelProviderName.OPENAI:
             return (
                 character.settings?.secrets?.OPENAI_API_KEY ||


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

fix scary start up warnings for firing it up out of the box

```
 ["◎ DirectClient constructor"] 

 ["⛔ Failed to get token - unsupported model provider: llama_local"] 

 ⛔ ERRORS
   Error starting agent for character Eliza: 
   {} 

 ["⛔ Error: Failed to get token - unsupported model provider: llama_local"] 

 ⛔ ERRORS
   Error starting agents: 
   {} 

 ["◎ Run `pnpm start:client` to start the client and visit the outputted URL (http://localhost:5173) to chat with your agents"] 

```

## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

Improved new developer experience, reduce confusion

# Documentation changes needed?

My changes do not require a change to the project documentation.