### PR TITLE
doc: add Twitter automation label notice (#1253)

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -171,6 +171,8 @@ TWITTER_EMAIL=    # Account email
 TWITTER_COOKIES=  # Account cookies (auth_token and CT0)
 ```
 
+**Important:** Log in to the [Twitter Developer Portal](https://developer.twitter.com) and enable the "Automated" label for your account to avoid being flagged as inauthentic.
+
 Example for TWITTER_COOKIES
 
 The TWITTER_COOKIES variable should be a JSON string containing the necessary cookies. You can find these cookies in your web browser's developer tools. Here is an example format:


### PR DESCRIPTION
## Description
Add a brief notice about the required Twitter "Automated" label setup in the quickstart guide to prevent accounts from being flagged.

Fixes #1253 

## Context
Multiple users have reported their agents being flagged when not properly labeled as automated accounts.

## Changes
Add a single line notice about enabling the "Automated" label via Developer Portal:
```bash
**Important:** Log in to the [Twitter Developer Portal](https://developer.twitter.com) and enable the "Automated" label for your account to avoid being flagged as inauthentic.