### PR TITLE
feat: Add caching support for Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Cache Configs
+CACHE_STORE=database # Defaults to database. Other available cache store: redis and filesystem
+REDIS_URL= # Redis URL - could be a local redis instance or cloud hosted redis. Also support rediss:// urls
+
 # Discord Configuration
 DISCORD_APPLICATION_ID=
 DISCORD_API_TOKEN=              # Bot token

--- a/agent/package.json
+++ b/agent/package.json
@@ -1,61 +1,62 @@
 {
-  "name": "@ai16z/agent",
-  "version": "0.1.6-alpha.4",
-  "main": "src/index.ts",
-  "type": "module",
-  "scripts": {
-    "start": "node --loader ts-node/esm src/index.ts",
-    "dev": "node --loader ts-node/esm src/index.ts",
-    "check-types": "tsc --noEmit"
-  },
-  "nodemonConfig": {
-    "watch": [
-      "src",
-      "../core/dist"
-    ],
-    "ext": "ts,json",
-    "exec": "node --enable-source-maps --loader ts-node/esm src/index.ts"
-  },
-  "dependencies": {
-    "@ai16z/adapter-postgres": "workspace:*",
-    "@ai16z/adapter-sqlite": "workspace:*",
-    "@ai16z/client-auto": "workspace:*",
-    "@ai16z/client-direct": "workspace:*",
-    "@ai16z/client-discord": "workspace:*",
-    "@ai16z/client-farcaster": "workspace:*",
-    "@ai16z/client-lens": "workspace:*",
-    "@ai16z/client-telegram": "workspace:*",
-    "@ai16z/client-twitter": "workspace:*",
-    "@ai16z/client-slack": "workspace:*",
-    "@ai16z/eliza": "workspace:*",
-    "@ai16z/plugin-0g": "workspace:*",
-    "@ai16z/plugin-aptos": "workspace:*",
-    "@ai16z/plugin-bootstrap": "workspace:*",
-    "@ai16z/plugin-intiface": "workspace:*",
-    "@ai16z/plugin-coinbase": "workspace:*",
-    "@ai16z/plugin-conflux": "workspace:*",
-    "@ai16z/plugin-evm": "workspace:*",
-    "@ai16z/plugin-flow": "workspace:*",
-    "@ai16z/plugin-story": "workspace:*",
-    "@ai16z/plugin-goat": "workspace:*",
-    "@ai16z/plugin-icp": "workspace:*",
-    "@ai16z/plugin-image-generation": "workspace:*",
-    "@ai16z/plugin-nft-generation": "workspace:*",
-    "@ai16z/plugin-node": "workspace:*",
-    "@ai16z/plugin-solana": "workspace:*",
-    "@ai16z/plugin-starknet": "workspace:*",
-    "@ai16z/plugin-ton": "workspace:*",
-    "@ai16z/plugin-sui": "workspace:*",
-    "@ai16z/plugin-tee": "workspace:*",
-    "@ai16z/plugin-multiversx": "workspace:*",
-    "@ai16z/plugin-near": "workspace:*",
-    "@ai16z/plugin-zksync-era": "workspace:*",
-    "readline": "1.3.0",
-    "ws": "8.18.0",
-    "yargs": "17.7.2"
-  },
-  "devDependencies": {
-    "ts-node": "10.9.2",
-    "tsup": "8.3.5"
-  }
+    "name": "@ai16z/agent",
+    "version": "0.1.6-alpha.4",
+    "main": "src/index.ts",
+    "type": "module",
+    "scripts": {
+        "start": "node --loader ts-node/esm src/index.ts",
+        "dev": "node --loader ts-node/esm src/index.ts",
+        "check-types": "tsc --noEmit"
+    },
+    "nodemonConfig": {
+        "watch": [
+            "src",
+            "../core/dist"
+        ],
+        "ext": "ts,json",
+        "exec": "node --enable-source-maps --loader ts-node/esm src/index.ts"
+    },
+    "dependencies": {
+        "@ai16z/adapter-postgres": "workspace:*",
+        "@ai16z/adapter-redis": "workspace:*",
+        "@ai16z/adapter-sqlite": "workspace:*",
+        "@ai16z/client-auto": "workspace:*",
+        "@ai16z/client-direct": "workspace:*",
+        "@ai16z/client-discord": "workspace:*",
+        "@ai16z/client-farcaster": "workspace:*",
+        "@ai16z/client-lens": "workspace:*",
+        "@ai16z/client-telegram": "workspace:*",
+        "@ai16z/client-twitter": "workspace:*",
+        "@ai16z/client-slack": "workspace:*",
+        "@ai16z/eliza": "workspace:*",
+        "@ai16z/plugin-0g": "workspace:*",
+        "@ai16z/plugin-aptos": "workspace:*",
+        "@ai16z/plugin-bootstrap": "workspace:*",
+        "@ai16z/plugin-intiface": "workspace:*",
+        "@ai16z/plugin-coinbase": "workspace:*",
+        "@ai16z/plugin-conflux": "workspace:*",
+        "@ai16z/plugin-evm": "workspace:*",
+        "@ai16z/plugin-flow": "workspace:*",
+        "@ai16z/plugin-story": "workspace:*",
+        "@ai16z/plugin-goat": "workspace:*",
+        "@ai16z/plugin-icp": "workspace:*",
+        "@ai16z/plugin-image-generation": "workspace:*",
+        "@ai16z/plugin-nft-generation": "workspace:*",
+        "@ai16z/plugin-node": "workspace:*",
+        "@ai16z/plugin-solana": "workspace:*",
+        "@ai16z/plugin-starknet": "workspace:*",
+        "@ai16z/plugin-ton": "workspace:*",
+        "@ai16z/plugin-sui": "workspace:*",
+        "@ai16z/plugin-tee": "workspace:*",
+        "@ai16z/plugin-multiversx": "workspace:*",
+        "@ai16z/plugin-near": "workspace:*",
+        "@ai16z/plugin-zksync-era": "workspace:*",
+        "readline": "1.3.0",
+        "ws": "8.18.0",
+        "yargs": "17.7.2"
+    },
+    "devDependencies": {
+        "ts-node": "10.9.2",
+        "tsup": "8.3.5"
+    }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -993,6 +993,12 @@ export type CacheOptions = {
     expires?: number;
 };
 
+export enum CacheStore {
+    REDIS = "redis",
+    DATABASE = "database",
+    FILESYSTEM = "filesystem",
+}
+
 export interface ICacheManager {
     get<T = unknown>(key: string): Promise<T | undefined>;
     set<T>(key: string, value: T, options?: CacheOptions): Promise<void>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@ai16z/adapter-postgres':
         specifier: workspace:*
         version: link:../packages/adapter-postgres
+      '@ai16z/adapter-redis':
+        specifier: workspace:*
+        version: link:../packages/adapter-redis
       '@ai16z/adapter-sqlite':
         specifier: workspace:*
         version: link:../packages/adapter-sqlite


### PR DESCRIPTION
This PR implements a flexible caching mechanism into the agent that supports Redis, Database, and File System as configurable options.

**Notes:**
- Requires `CACHE_STORE` environment variable. Support values are `redis`, `database`, `filesystem`.
- Requires `REDIS_URL` environment variable for Redis caching.
