### PR TITLE
fix: {{user}} tags in templates/examples empty when passed to LLM

### DIFF
--- a/packages/client-discord/src/messages.ts
+++ b/packages/client-discord/src/messages.ts
@@ -1,4 +1,4 @@
-import { composeContext } from "@ai16z/eliza";
+import { composeContext, composeRandomUser } from "@ai16z/eliza";
 import { generateMessageResponse, generateShouldRespond } from "@ai16z/eliza";
 import {
     Content,
@@ -1228,7 +1228,7 @@ export class MessageManager {
                 this.runtime.character.templates
                     ?.discordShouldRespondTemplate ||
                 this.runtime.character.templates?.shouldRespondTemplate ||
-                discordShouldRespondTemplate,
+                composeRandomUser(discordShouldRespondTemplate, 2),
         });
 
         const response = await generateShouldRespond({

--- a/packages/client-discord/src/templates.ts
+++ b/packages/client-discord/src/templates.ts
@@ -8,48 +8,48 @@ About {{agentName}}:
 # INSTRUCTIONS: Determine if {{agentName}} should respond to the message and participate in the conversation. Do not comment. Just respond with "RESPOND" or "IGNORE" or "STOP".
 
 # RESPONSE EXAMPLES
-<user 1>: I just saw a really great movie
-<user 2>: Oh? Which movie?
+{{user1}}: I just saw a really great movie
+{{user2}}: Oh? Which movie?
 Result: [IGNORE]
 
 {{agentName}}: Oh, this is my favorite scene
-<user 1>: sick
-<user 2>: wait, why is it your favorite scene
+{{user1}}: sick
+{{user2}}: wait, why is it your favorite scene
 Result: [RESPOND]
 
-<user>: stfu bot
+{{user1}}: stfu bot
 Result: [STOP]
 
-<user>: Hey {{agent}}, can you help me with something
+{{user1}}: Hey {{agent}}, can you help me with something
 Result: [RESPOND]
 
-<user>: {{agentName}} stfu plz
+{{user1}}: {{agentName}} stfu plz
 Result: [STOP]
 
-<user>: i need help
+{{user1}}: i need help
 {{agentName}}: how can I help you?
-<user>: no. i need help from someone else
+{{user1}}: no. i need help from someone else
 Result: [IGNORE]
 
-<user>: Hey {{agent}}, can I ask you a question
+{{user1}}: Hey {{agent}}, can I ask you a question
 {{agentName}}: Sure, what is it
-<user>: can you ask claude to create a basic react module that demonstrates a counter
+{{user1}}: can you ask claude to create a basic react module that demonstrates a counter
 Result: [RESPOND]
 
-<user>: {{agentName}} can you tell me a story
-<user>: {about a girl named elara
+{{user1}}: {{agentName}} can you tell me a story
+{{user1}}: about a girl named elara
 {{agentName}}: Sure.
 {{agentName}}: Once upon a time, in a quaint little village, there was a curious girl named Elara.
 {{agentName}}: Elara was known for her adventurous spirit and her knack for finding beauty in the mundane.
-<user>: I'm loving it, keep going
+{{user1}}: I'm loving it, keep going
 Result: [RESPOND]
 
-<user>: {{agentName}} stop responding plz
+{{user1}}: {{agentName}} stop responding plz
 Result: [STOP]
 
-<user>: okay, i want to test something. can you say marco?
+{{user1}}: okay, i want to test something. can you say marco?
 {{agentName}}: marco
-<user>: great. okay, now do it again
+{{user1}}: great. okay, now do it again
 Result: [RESPOND]
 
 Response options are [RESPOND], [IGNORE] and [STOP].

--- a/packages/client-discord/src/voice.ts
+++ b/packages/client-discord/src/voice.ts
@@ -8,6 +8,7 @@ import {
     State,
     UUID,
     composeContext,
+    composeRandomUser,
     elizaLogger,
     getEmbeddingZeroVector,
     generateMessageResponse,
@@ -840,7 +841,7 @@ export class VoiceManager extends EventEmitter {
                 this.runtime.character.templates
                     ?.discordShouldRespondTemplate ||
                 this.runtime.character.templates?.shouldRespondTemplate ||
-                discordShouldRespondTemplate,
+                composeRandomUser(discordShouldRespondTemplate, 2),
         });
 
         const response = await generateShouldRespond({

--- a/packages/client-telegram/src/messageManager.ts
+++ b/packages/client-telegram/src/messageManager.ts
@@ -1,7 +1,7 @@
 import { Message } from "@telegraf/types";
 import { Context, Telegraf } from "telegraf";
 
-import { composeContext, elizaLogger, ServiceType } from "@ai16z/eliza";
+import { composeContext, elizaLogger, ServiceType, composeRandomUser } from "@ai16z/eliza";
 import { getEmbeddingZeroVector } from "@ai16z/eliza";
 import {
     Content,
@@ -559,13 +559,14 @@ export class MessageManager {
 
         // Use AI to decide for text or captions
         if ("text" in message || ("caption" in message && message.caption)) {
+            
             const shouldRespondContext = composeContext({
                 state,
                 template:
                     this.runtime.character.templates
                         ?.telegramShouldRespondTemplate ||
                     this.runtime.character?.templates?.shouldRespondTemplate ||
-                    telegramShouldRespondTemplate,
+                    composeRandomUser(telegramShouldRespondTemplate, 2),
             });
 
             const response = await generateShouldRespond({

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,5 +1,7 @@
 import handlebars from "handlebars";
 import { type State } from "./types.ts";
+import { names, uniqueNamesGenerator } from "unique-names-generator";
+
 
 /**
  * Composes a context string by replacing placeholders in a template with corresponding values from the state.
@@ -69,3 +71,37 @@ export const composeContext = ({
 export const addHeader = (header: string, body: string) => {
     return body.length > 0 ? `${header ? header + "\n" : header}${body}\n` : "";
 };
+
+/**
+ * Generates a string with random user names populated in a template.
+ *
+ * This function generates a specified number of random user names and populates placeholders
+ * in the provided template with these names. Placeholders in the template should follow the format `{{userX}}`
+ * where `X` is the position of the user (e.g., `{{user1}}`, `{{user2}}`).
+ *
+ * @param {Object} params - The parameters for generating the composed string.
+ * @param {string} params.template - The template string containing placeholders for random user names.
+ * @param {number} params.length - The number of random user names to generate.
+ * @returns {string} The template string with placeholders replaced by random user names.
+ *
+ * @example
+ * // Given a template and a length
+ * const template = "Hello, {{user1}}! Meet {{user2}} and {{user3}}.";
+ * const length = 3;
+ *
+ * // Composing the random user string will result in:
+ * // "Hello, John! Meet Alice and Bob."
+ * const result = composeRandomUser({ template, length });
+ */
+export const composeRandomUser = (template: string, length: number) => {
+    const exampleNames = Array.from({ length }, () =>
+        uniqueNamesGenerator({ dictionaries: [names] })
+    );
+    let result = template;
+    for (let i = 0; i < exampleNames.length; i++) {
+        result = result.replaceAll(`{{user${i + 1}}}`, exampleNames[i]);
+    }
+
+    return result;
+};
+


### PR DESCRIPTION
related: https://github.com/ai16z/eliza/issues/1267

<img width="996" alt="截圖 2024-12-20 下午11 08 14" src="https://github.com/user-attachments/assets/4383c9b1-b88c-4b82-8b89-4d5384bcb8b0" />
