### PR TITLE
no token needed for gaianet

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -214,8 +214,10 @@ export function getTokenForProvider(
     character: Character
 ): string {
     switch (provider) {
-        // no key needed for llama_local
+        // no key needed for llama_local or gaianet
         case ModelProviderName.LLAMALOCAL:
+            return "";
+        case ModelProviderName.GAIANET:
             return "";
         case ModelProviderName.OPENAI:
             return (


### PR DESCRIPTION
update getting tokens to reflect no key needed for gaianet. Don't throw an error here.

# Relates to:

getTokenForProvider function. 

# Risks

Low risk, simply does not throw an error for gaianet anymore. 

## What kind of change is this?

Bug fix

## Why are we doing this? Any context or related work?

We are doing this so that gaianet is supported here. 

# Documentation changes needed?

My changes do not require a change to the project documentation.
