### PR TITLE
Update farcaster client max cast length

### DIFF
--- a/packages/client-farcaster/src/post.ts
+++ b/packages/client-farcaster/src/post.ts
@@ -8,7 +8,7 @@ import {
 } from "@ai16z/eliza";
 import { FarcasterClient } from "./client";
 import { formatTimeline, postTemplate } from "./prompts";
-import { castUuid } from "./utils";
+import {castUuid, MAX_CAST_LENGTH} from "./utils";
 import { createCastMemory } from "./memory";
 import { sendCast } from "./actions";
 
@@ -100,22 +100,20 @@ export class FarcasterPostManager {
 
             const slice = newContent.replaceAll(/\\n/g, "\n").trim();
 
-            const contentLength = 240;
+            let content = slice.slice(0, MAX_CAST_LENGTH);
 
-            let content = slice.slice(0, contentLength);
-
-            // if its bigger than 280, delete the last line
-            if (content.length > 280) {
+            // if it's bigger than the max limit, delete the last line
+            if (content.length > MAX_CAST_LENGTH) {
                 content = content.slice(0, content.lastIndexOf("\n"));
             }
 
-            if (content.length > contentLength) {
+            if (content.length > MAX_CAST_LENGTH) {
                 // slice at the last period
                 content = content.slice(0, content.lastIndexOf("."));
             }
 
             // if it's still too long, get the period before the last period
-            if (content.length > contentLength) {
+            if (content.length > MAX_CAST_LENGTH) {
                 content = content.slice(0, content.lastIndexOf("."));
             }
 

--- a/packages/client-farcaster/src/utils.ts
+++ b/packages/client-farcaster/src/utils.ts
@@ -1,6 +1,6 @@
 import { stringToUuid } from "@ai16z/eliza";
 
-const MAX_CAST_LENGTH = 280; // Updated to Twitter's current character limit
+const MAX_CAST_LENGTH = 1024; // Updated to Twitter's current character limit
 
 export function castId({ hash, agentId }: { hash: string; agentId: string }) {
     return `${hash}-${agentId}`;

--- a/packages/client-farcaster/src/utils.ts
+++ b/packages/client-farcaster/src/utils.ts
@@ -1,6 +1,6 @@
 import { stringToUuid } from "@ai16z/eliza";
 
-const MAX_CAST_LENGTH = 1024; // Updated to Twitter's current character limit
+export const MAX_CAST_LENGTH = 1024; // Updated to Twitter's current character limit
 
 export function castId({ hash, agentId }: { hash: string; agentId: string }) {
     return `${hash}-${agentId}`;


### PR DESCRIPTION

# Risks

Medium risk: I don't know if neynar's APIs support long casts with 1024 length without any additional flags as I couldn't find the limit documented or if there are any other parameters except for `text` in their publishCast function. I don't have an account to test it. The value takes into consideration the byte length of the cast, so maybe unicode characters of 1024 length will fail.

# Background

## What does this PR do?

## What kind of change is this?

The cast limit for farcaster client has been modified to match the [protocol's spec](https://github.com/farcasterxyz/protocol/blob/main/docs/SPECIFICATION.md#24-casts)

## Why are we doing this? Any context or related work?

I wanted it to match the spec instead of the currently incorrectly defined limit

# Documentation changes needed?

I don't think there's any documentation for the Farcaster client at the moment

# Testing

## Where should a reviewer start?

If you have a neynar account try posting a cast with a message size of 1024 bytes
